### PR TITLE
✨ feat: 포인트 조회 구현

### DIFF
--- a/src/main/java/com/grow/member_service/common/exception/PointHistoryException.java
+++ b/src/main/java/com/grow/member_service/common/exception/PointHistoryException.java
@@ -1,0 +1,15 @@
+package com.grow.member_service.common.exception;
+
+import com.grow.member_service.global.exception.ErrorCode;
+import com.grow.member_service.global.exception.ServiceException;
+
+public class PointHistoryException extends ServiceException {
+
+	public PointHistoryException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public PointHistoryException(ErrorCode errorCode, Throwable cause) {
+		super(errorCode, cause);
+	}
+}

--- a/src/main/java/com/grow/member_service/global/exception/ErrorCode.java
+++ b/src/main/java/com/grow/member_service/global/exception/ErrorCode.java
@@ -29,6 +29,10 @@ public enum ErrorCode {
 	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "404-1", "review.not.found"),
 	REVIEW_SELF_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "400-13", "review.self.not.allowed"),
 
+	// 포인트 도메인
+	POINT_PERIOD_INCOMPLETE(HttpStatus.BAD_REQUEST, "400-14", "point.period.incomplete"),
+	POINT_PERIOD_INVALID_RANGE( HttpStatus.BAD_REQUEST, "400-15", "point.period.invalid.range"),
+
 	// OAuth 관련
 	OAUTH_UNSUPPORTED_PLATFORM(HttpStatus.BAD_REQUEST, "400-3", "oauth.unsupported.platform"),
 	OAUTH_MISSING_PLATFORM_ID(HttpStatus.BAD_REQUEST, "400-4", "oauth.missing.platform.id"),

--- a/src/main/java/com/grow/member_service/history/point/application/dto/PointHistoryResponse.java
+++ b/src/main/java/com/grow/member_service/history/point/application/dto/PointHistoryResponse.java
@@ -1,0 +1,32 @@
+package com.grow.member_service.history.point.application.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+
+@Getter
+public class PointHistoryResponse {
+	private final Long pointHistoryId;
+	private final Integer amount;
+	private final String content;
+	private final LocalDateTime addAt;
+
+	public PointHistoryResponse(Long pointHistoryId,
+		Integer amount,
+		String content,
+		LocalDateTime addAt) {
+		this.pointHistoryId = pointHistoryId;
+		this.amount = amount;
+		this.content = content;
+		this.addAt = addAt;
+	}
+
+	public static PointHistoryResponse fromDomain(com.grow.member_service.history.point.domain.model.PointHistory ph) {
+		return new PointHistoryResponse(
+			ph.getPointHistoryId(),
+			ph.getAmount(),
+			ph.getContent(),
+			ph.getAddAt()
+		);
+	}
+}

--- a/src/main/java/com/grow/member_service/history/point/application/model/Period.java
+++ b/src/main/java/com/grow/member_service/history/point/application/model/Period.java
@@ -1,0 +1,32 @@
+package com.grow.member_service.history.point.application.model;
+
+import java.time.LocalDateTime;
+
+import com.grow.member_service.common.exception.PointHistoryException;
+import com.grow.member_service.global.exception.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class Period {
+
+	private final LocalDateTime startAt;
+	private final LocalDateTime endAt;
+
+	/**
+	 * 조회 기간을 나타내는 Value Object
+	 * @param startAt 조회 시작일시
+	 * @param endAt   조회 종료일시
+	 * @throws IllegalArgumentException startAt이 endAt 이후일 경우
+	 */
+	public Period(LocalDateTime startAt, LocalDateTime endAt) {
+		if (startAt == null || endAt == null) {
+			throw new PointHistoryException(ErrorCode.POINT_PERIOD_INCOMPLETE);
+		}
+		if (startAt.isAfter(endAt)) {
+			throw new PointHistoryException(ErrorCode.POINT_PERIOD_INVALID_RANGE);
+		}
+		this.startAt = startAt;
+		this.endAt   = endAt;
+	}
+}

--- a/src/main/java/com/grow/member_service/history/point/application/service/PointHistoryApplicationService.java
+++ b/src/main/java/com/grow/member_service/history/point/application/service/PointHistoryApplicationService.java
@@ -1,0 +1,48 @@
+package com.grow.member_service.history.point.application.service;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import com.grow.member_service.history.point.application.model.Period;
+import com.grow.member_service.history.point.application.dto.PointHistoryResponse;
+import com.grow.member_service.history.point.domain.model.PointHistory;
+import com.grow.member_service.history.point.domain.repository.PointHistoryRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PointHistoryApplicationService {
+
+	private final PointHistoryRepository repository;
+
+	/**
+	 * 페이징·정렬 + (옵션)기간 필터링 조회
+	 */
+	public Page<PointHistoryResponse> searchHistories(
+		Long memberId,
+		LocalDateTime startAt,
+		LocalDateTime endAt,
+		Pageable pageable
+	) {
+		Page<PointHistory> domainPage;
+
+		if (startAt != null && endAt != null) {
+			// Application 레이어에서 VO 생성 + 검증
+			Period period = new Period(startAt, endAt);
+			domainPage = repository.findByMemberIdAndPeriod(
+				memberId,
+				period.getStartAt(),
+				period.getEndAt(),
+				pageable
+			);
+		} else {
+			domainPage = repository.findByMemberId(memberId, pageable);
+		}
+
+		return domainPage.map(PointHistoryResponse::fromDomain);
+	}
+}

--- a/src/main/java/com/grow/member_service/history/point/domain/repository/PointHistoryRepository.java
+++ b/src/main/java/com/grow/member_service/history/point/domain/repository/PointHistoryRepository.java
@@ -1,11 +1,27 @@
 package com.grow.member_service.history.point.domain.repository;
 
-import com.grow.member_service.history.point.domain.model.PointHistory;
-
+import java.time.LocalDateTime;
 import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import com.grow.member_service.history.point.domain.model.PointHistory;
 
 public interface PointHistoryRepository {
     PointHistory save(PointHistory pointHistory);
     List<PointHistory> findByMemberId(Long id);
     void delete(PointHistory pointHistory);
+
+    // 페이징 조회
+    Page<PointHistory> findByMemberId(Long memberId, Pageable pageable);
+
+    // 기간(startAt~endAt) 필터링 + 페이징
+    Page<PointHistory> findByMemberIdAndPeriod(
+        Long memberId,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        Pageable pageable
+    );
+
 }

--- a/src/main/java/com/grow/member_service/history/point/infra/persistence/repository/PointHistoryImpl.java
+++ b/src/main/java/com/grow/member_service/history/point/infra/persistence/repository/PointHistoryImpl.java
@@ -1,14 +1,19 @@
 package com.grow.member_service.history.point.infra.persistence.repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
 import com.grow.member_service.history.point.domain.model.PointHistory;
 import com.grow.member_service.history.point.domain.repository.PointHistoryRepository;
 import com.grow.member_service.history.point.infra.persistence.entity.PointHistoryJpaEntity;
 import com.grow.member_service.history.point.infra.persistence.mapper.PointHistoryMapper;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
@@ -28,6 +33,23 @@ public class PointHistoryImpl implements PointHistoryRepository {
         return jpaRepository.findByMemberId(id)
                 .stream().map(mapper::toDomain)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public Page<PointHistory> findByMemberId(Long memberId, Pageable pageable) {
+        return jpaRepository.findByMemberId(memberId, pageable)
+            .map(mapper::toDomain);
+    }
+
+    @Override
+    public Page<PointHistory> findByMemberIdAndPeriod(
+        Long memberId,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        Pageable pageable
+    ) {
+        return jpaRepository.findByMemberIdAndAddAtBetween(memberId, startAt, endAt, pageable)
+            .map(mapper::toDomain);
     }
 
     @Override

--- a/src/main/java/com/grow/member_service/history/point/infra/persistence/repository/PointHistoryJpaRepository.java
+++ b/src/main/java/com/grow/member_service/history/point/infra/persistence/repository/PointHistoryJpaRepository.java
@@ -1,10 +1,21 @@
 package com.grow.member_service.history.point.infra.persistence.repository;
 
-import com.grow.member_service.history.point.infra.persistence.entity.PointHistoryJpaEntity;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
+import com.grow.member_service.history.point.infra.persistence.entity.PointHistoryJpaEntity;
 
 public interface PointHistoryJpaRepository extends JpaRepository<PointHistoryJpaEntity, Long> {
     List<PointHistoryJpaEntity> findByMemberId(Long memberId);
+    Page<PointHistoryJpaEntity> findByMemberId(Long memberId, Pageable pageable);
+    Page<PointHistoryJpaEntity> findByMemberIdAndAddAtBetween(
+        Long memberId,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        Pageable pageable
+    );
 }

--- a/src/main/java/com/grow/member_service/history/point/infra/persistence/repository/PointHistoryRepositoryImpl.java
+++ b/src/main/java/com/grow/member_service/history/point/infra/persistence/repository/PointHistoryRepositoryImpl.java
@@ -17,7 +17,7 @@ import lombok.RequiredArgsConstructor;
 
 @Repository
 @RequiredArgsConstructor
-public class PointHistoryImpl implements PointHistoryRepository {
+public class PointHistoryRepositoryImpl implements PointHistoryRepository {
 
     private final PointHistoryJpaRepository jpaRepository;
     private final PointHistoryMapper mapper;

--- a/src/main/java/com/grow/member_service/history/point/presentation/controller/PointHistoryController.java
+++ b/src/main/java/com/grow/member_service/history/point/presentation/controller/PointHistoryController.java
@@ -1,0 +1,65 @@
+package com.grow.member_service.history.point.presentation.controller;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.grow.member_service.global.dto.RsData;
+import com.grow.member_service.history.point.application.dto.PointHistoryResponse;
+import com.grow.member_service.history.point.application.service.PointHistoryApplicationService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/points")
+@Tag(name = "PointHistory", description = "포인트 내역 관련 API")
+@Validated
+public class PointHistoryController {
+
+	private final PointHistoryApplicationService service;
+
+	@Operation(
+		summary = "내 포인트 내역 조회",
+		description = "옵션으로 기간을 파라미터로 받아 페이징/정렬하여 조회. 미입력 시 전체 내역 반환"
+	)
+	@GetMapping("/me")
+	public ResponseEntity<RsData<Page<PointHistoryResponse>>> getMyPointHistories(
+		@AuthenticationPrincipal Long memberId,
+
+		@Parameter(description = "조회 시작일시", example = "2025-07-01T00:00:00")
+		@RequestParam(required = false)
+		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+		LocalDateTime startAt,
+
+		@Parameter(description = "조회 종료일시", example = "2025-07-15T23:59:59")
+		@RequestParam(required = false)
+		@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+		LocalDateTime endAt,
+
+		@PageableDefault(size = 20, sort = "addAt", direction = Sort.Direction.DESC)
+		Pageable pageable
+	) {
+		Page<PointHistoryResponse> page = service.searchHistories(
+			memberId,
+			startAt,
+			endAt,
+			pageable
+		);
+		return ResponseEntity.ok(new RsData<>("200", "내 포인트 내역 조회 성공", page));
+	}
+}

--- a/src/main/java/com/grow/member_service/history/point/presentation/dto/PointHistorySearchRequest.java
+++ b/src/main/java/com/grow/member_service/history/point/presentation/dto/PointHistorySearchRequest.java
@@ -1,0 +1,28 @@
+package com.grow.member_service.history.point.presentation.dto;
+
+import java.time.LocalDateTime;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.jackson.Jacksonized;
+
+@Getter
+@Builder
+@Jacksonized
+public class PointHistorySearchRequest {
+
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+	private final LocalDateTime startAt;
+
+	@DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+	private final LocalDateTime endAt;
+
+	@AssertTrue(message = "조회 시작일시는 종료일시보다 이전이거나 같아야 합니다.")
+	private boolean isValidPeriod() {
+		if (startAt == null || endAt == null) return true;
+		return !startAt.isAfter(endAt);
+	}
+}

--- a/src/main/java/com/grow/member_service/member/presentation/controller/MemberController.java
+++ b/src/main/java/com/grow/member_service/member/presentation/controller/MemberController.java
@@ -16,14 +16,12 @@ import com.grow.member_service.member.presentation.dto.MemberUpdateRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
-@SecurityRequirement(name = "cookieAuth")
 @Tag(name= "Member", description = "회원 관련 API")
 public class MemberController {
 	private final MemberApplicationService memberApplicationService;

--- a/src/main/java/com/grow/member_service/quiz/result/presentation/controller/QuizResultController.java
+++ b/src/main/java/com/grow/member_service/quiz/result/presentation/controller/QuizResultController.java
@@ -21,14 +21,12 @@ import com.grow.member_service.quiz.result.presentation.dto.QuizStatsResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/quizzes")
-@SecurityRequirement(name = "cookieAuth")
 @Tag(name = "QuizResult", description = "퀴즈 결과 관리 API")
 public class QuizResultController {
 	private final QuizResultService quizResultService;

--- a/src/main/java/com/grow/member_service/review/presentation/controller/ReviewController.java
+++ b/src/main/java/com/grow/member_service/review/presentation/controller/ReviewController.java
@@ -19,14 +19,12 @@ import com.grow.member_service.review.presentation.dto.ReviewSubmitRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/reviews")
-@SecurityRequirement(name = "cookieAuth")
 @Tag(name = "Review", description = "리뷰 관련 API")
 public class ReviewController {
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -20,3 +20,6 @@ sms.send.failed=SMS 전송에 실패했습니다.
 review.not.found=리뷰를 찾을 수 없습니다.
 review.already.exists=이미 작성한 리뷰가 있습니다.
 review.self.not.allowed=자신의 리뷰는 작성할 수 없습니다.
+# 포인트
+point.period.incomplete=조회 시작일시와 종료일시는 모두 입력되어야 합니다.
+point.period.invalid.range=조회 시작일시는 종료일시 이전이거나 같아야 합니다.


### PR DESCRIPTION
## 🔍 Title(필수)
#15 

## 🔗 Related Issues(필수)
Closes #15 

## 📝 Note (주의 사항)
- 포인트 내역 조회 API
    - GET /api/points/me 엔드포인트 추가
    - startAt/endAt 쿼리 파라미터로 기간 필터링 지원
    - page, size, sort 파라미터로 페이징·정렬 적용
    - 기간 파라미터가 없으면 전체 내역을 페이징된 형태로 반환

- DataInitializer 수정
    - 애플리케이션 기동 시 테스트용 멤버에 60건의 포인트 내역 자동 생성