### PR TITLE
✨ feat: 멤버 신뢰도 점수 스케줄링 로직 추가 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,6 +125,9 @@ dependencies {
 
 	// 기타
 	implementation 'net.datafaker:datafaker:2.4.4' // 무작위 이름 생성기
+
+	// redis cache
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.5.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grow/member_service/MemberServiceApplication.java
+++ b/src/main/java/com/grow/member_service/MemberServiceApplication.java
@@ -2,7 +2,9 @@ package com.grow.member_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class MemberServiceApplication {
 

--- a/src/main/java/com/grow/member_service/member/application/config/RedisConfig.java
+++ b/src/main/java/com/grow/member_service/member/application/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package com.grow.member_service.member.application.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Double> customDoubleRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Double> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Double.class));
+
+        template.afterPropertiesSet();
+        return template;
+    }
+}

--- a/src/main/java/com/grow/member_service/member/application/dto/MemberScoreDto.java
+++ b/src/main/java/com/grow/member_service/member/application/dto/MemberScoreDto.java
@@ -1,0 +1,30 @@
+package com.grow.member_service.member.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * <h2>멤버 점수 DTO</h2>
+ *
+ * <p>이 클래스는 멤버의 ID와 신뢰 점수를 전달하기 위한 데이터 전송 객체(DTO)입니다.
+ * 데이터베이스 조회 결과를 캡슐화하여 서비스 계층 ScoreUpdateService에서 Redis 업데이트 시 활용됩니다.</p>
+ *
+ * <ol>
+ *   <li>필드:
+ *       <ul>
+ *         <li>memberId: 멤버의 고유 ID (Long 타입)</li>
+ *         <li>score: 멤버의 신뢰 점수 (Double 타입)</li>
+ *       </ul>
+ *   </li>
+ *   <li>용도: MemberRepository의 Projection 결과를 매핑하여 처리 (Projection -> 인프라 레이어의 DTO)</li>
+ * </ol>
+ */
+@Getter
+@ToString
+@AllArgsConstructor
+public class MemberScoreDto {
+
+    private Long memberId;
+    private Double score;
+}

--- a/src/main/java/com/grow/member_service/member/application/service/ScoreUpdateService.java
+++ b/src/main/java/com/grow/member_service/member/application/service/ScoreUpdateService.java
@@ -1,0 +1,87 @@
+package com.grow.member_service.member.application.service;
+
+import com.grow.member_service.member.application.dto.MemberScoreDto;
+import com.grow.member_service.member.domain.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * <h2>멤버 신뢰 점수 업데이트 서비스</h2>
+ *
+ * <p>이 클래스는 멤버의 신뢰 점수를 Redis에 저장하고 업데이트하는 역할을 수행합니다.
+ * 개별 멤버의 점수를 저장/업데이트하는 메서드와, 매일 자정에 모든 멤버의 점수를 데이터베이스에서 조회하여
+ * Redis에 동기화하는 스케줄링 작업을 포함합니다. Spring의 @Service로 정의되어 비즈니스 로직을 처리하며,
+ * RedisTemplate를 통해 Redis와 상호작용합니다.</p>
+ *
+ * <ol>
+ *   <li>의존성: MemberRepository를 통해 데이터베이스에서 점수 조회, RedisTemplate로 Redis 저장/업데이트</li>
+ *   <li>주요 메서드:
+ *       <ul>
+ *         <li>saveMemberScoreToRedis: 단일 멤버의 점수를 Redis에 저장/업데이트 (변경 시에만 적용)</li>
+ *         <li>updateAllMemberScores: 매일 자정 스케줄링으로 모든 멤버 점수 동기화</li>
+ *       </ul>
+ *   </li>
+ *   <li>Redis 키: "member:trust:score:{memberId}" 형식으로 사용</li>
+ * </ol>
+ *
+ * @since 2025.07.28
+ */
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ScoreUpdateService {
+
+    private final MemberRepository memberRepository;
+    private final RedisTemplate<String, Double> redisTemplate;
+
+    /**
+     * Redis 키의 접두사로 사용되는 상수. 멤버의 신뢰 점수를 저장하는 키를 생성합니다.
+     */
+    public static final String TRUST_KEY = "member:trust:score:";
+
+    /**
+     * 단일 멤버의 점수를 Redis에 저장하거나 업데이트하는 메서드.
+     * 기존 점수를 확인하고 변경된 경우에만 업데이트합니다.
+     *
+     * @param memberId 멤버의 ID
+     * @param score 저장할 점수 (Double 타입)
+     */
+    public void saveMemberScoreToRedis(Long memberId, Double score) {
+        // Redis 키 생성: TRUST_KEY와 memberId를 결합
+        String key = TRUST_KEY + memberId;
+        Double currentScore = redisTemplate.opsForValue().get(key); // 기존 값 확인
+
+        if (currentScore == null) { // 기존 값이 없으면 새로 저장
+            redisTemplate.opsForValue().set(key, score); // Double 타입으로 저장
+            log.info("[SCORE SAVE] {} 멤버의 score를 Redis에 저장했습니다.", memberId);
+        } else if (!currentScore.equals(score)) { // 변경된 내용이 있는 경우
+            redisTemplate.opsForValue().set(key, score);
+            log.info("[SCORE UPDATE] {} 멤버의 score를 Redis에 업데이트했습니다.", memberId);
+        } else { // 변경된 내용이 없는 경우: 아무 작업도 하지 않음
+            log.info("[SCORE SKIP] {} 멤버의 score는 변경되지 않았습니다.", memberId);
+        }
+    }
+
+    /**
+     * Spring의 @Scheduled 어노테이션을 사용하여 매일 자정에 실행되는 스케줄링 메서드.
+     * cron 표현식 "0 0 0 * * ?"은 매일 0시 0분 0초를 의미합니다.
+     * 모든 멤버의 점수를 데이터베이스에서 조회하여 Redis에 업데이트합니다.
+     *
+     * TODO: 분산 환경에서 중복 실행을 방지하기 위해 분산 락(Distributed Lock)을 고려
+     */
+    // 매일 자정에 모든 멤버의 score를 조건부 업데이트하는 스케줄러
+    @Scheduled(cron = "0 0 0 * * ?") // 매일 0시 0분 0초 실행
+    public void updateAllMemberScores() {
+        List<MemberScoreDto> allScores = memberRepository.findAllScore();// 한 번에 DTO 리스트 받음
+        for (MemberScoreDto dto : allScores) {
+            saveMemberScoreToRedis(dto.getMemberId(), dto.getScore()); // Redis에 score 업데이트
+        }
+        log.info("[REDIS SCHEDULED] 모든 멤버의 점수를 체크하고 Redis에 업데이트했습니다.");
+    }
+}

--- a/src/main/java/com/grow/member_service/member/application/service/ScoreUpdateService.java
+++ b/src/main/java/com/grow/member_service/member/application/service/ScoreUpdateService.java
@@ -1,6 +1,6 @@
 package com.grow.member_service.member.application.service;
 
-import com.grow.member_service.member.application.dto.MemberScoreDto;
+import com.grow.member_service.member.domain.model.MemberScoreInfo;
 import com.grow.member_service.member.domain.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -78,8 +78,8 @@ public class ScoreUpdateService {
     // 매일 자정에 모든 멤버의 score를 조건부 업데이트하는 스케줄러
     @Scheduled(cron = "0 0 0 * * ?") // 매일 0시 0분 0초 실행
     public void updateAllMemberScores() {
-        List<MemberScoreDto> allScores = memberRepository.findAllScore();// 한 번에 DTO 리스트 받음
-        for (MemberScoreDto dto : allScores) {
+        List<MemberScoreInfo> allScores = memberRepository.findAllScore();// 한 번에 DTO 리스트 받음
+        for (MemberScoreInfo dto : allScores) {
             saveMemberScoreToRedis(dto.getMemberId(), dto.getScore()); // Redis에 score 업데이트
         }
         log.info("[REDIS SCHEDULED] 모든 멤버의 점수를 체크하고 Redis에 업데이트했습니다.");

--- a/src/main/java/com/grow/member_service/member/application/service/ScoreUpdateService.java
+++ b/src/main/java/com/grow/member_service/member/application/service/ScoreUpdateService.java
@@ -9,6 +9,8 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * <h2>멤버 신뢰 점수 업데이트 서비스</h2>
@@ -50,7 +52,7 @@ public class ScoreUpdateService {
      * 기존 점수를 확인하고 변경된 경우에만 업데이트합니다.
      *
      * @param memberId 멤버의 ID
-     * @param score 저장할 점수 (Double 타입)
+     * @param score    저장할 점수 (Double 타입)
      */
     public void saveMemberScoreToRedis(Long memberId, Double score) {
         // Redis 키 생성: TRUST_KEY와 memberId를 결합
@@ -72,16 +74,75 @@ public class ScoreUpdateService {
      * Spring의 @Scheduled 어노테이션을 사용하여 매일 자정에 실행되는 스케줄링 메서드.
      * cron 표현식 "0 0 0 * * ?"은 매일 0시 0분 0초를 의미합니다.
      * 모든 멤버의 점수를 데이터베이스에서 조회하여 Redis에 업데이트합니다.
-     *
+     * <p>
      * TODO: 분산 환경에서 중복 실행을 방지하기 위해 분산 락(Distributed Lock)을 고려
      */
-    // 매일 자정에 모든 멤버의 score를 조건부 업데이트하는 스케줄러
+
     @Scheduled(cron = "0 0 0 * * ?") // 매일 0시 0분 0초 실행
     public void updateAllMemberScores() {
         List<MemberScoreInfo> allScores = memberRepository.findAllScore();// 한 번에 DTO 리스트 받음
-        for (MemberScoreInfo dto : allScores) {
-            saveMemberScoreToRedis(dto.getMemberId(), dto.getScore()); // Redis에 score 업데이트
+        // 실패한 회원들 저장할 큐 - key: memberId, value: score
+        ConcurrentLinkedQueue<MemberScoreInfo> failedUpdates = new ConcurrentLinkedQueue<>();
+
+        for (MemberScoreInfo scoreInfo : allScores) {
+            try {
+                saveMemberScoreToRedis(
+                        scoreInfo.getMemberId(),
+                        scoreInfo.getScore()
+                ); // Redis에 score 업데이트
+            } catch (Exception e) {
+                failedUpdates.add(scoreInfo); // 실패한 회원들 저장
+                log.error("[SCORE SAVE ERROR] {} 멤버의 score를 Redis에 저장하지 못했습니다.",
+                        scoreInfo.getMemberId(), e);
+            }
+        }
+
+        // 모든 작업이 끝난 후 실패 처리
+        if (!failedUpdates.isEmpty()) {
+            log.warn("[SCORE UPDATE FAILED] 총 {} 명의 멤버의 score를 Redis에 저장하지 못했습니다.",
+                    failedUpdates.size());
+            retryFailedUpdates(failedUpdates);  // 재시도 메서드 호출
         }
         log.info("[REDIS SCHEDULED] 모든 멤버의 점수를 체크하고 Redis에 업데이트했습니다.");
+    }
+
+    /**
+     * 실패한 멤버 점수 업데이트 항목들을 재시도하는 메서드입니다.
+     * 각 MemberScoreInfo에 대해 최대 3회 재시도를 수행하며, 병렬 스트림을 활용해 분산 환경에서 효율적으로 동작하도록 설계되었습니다.
+     * 재시도 실패 시 로그를 남기고, 영구 실패 처리를 위한 TODO를 포함합니다.
+     *
+     * @param failedUpdates 재시도할 실패한 MemberScoreInfo 항목들의 thread-safe 큐 (ConcurrentLinkedQueue).
+     *                      이 큐는 updateAllMemberScores 메서드에서 수집된 실패 항목을 포함합니다.
+     * @throws RuntimeException 재시도 중 예상치 못한 오류 발생 시 (예: Redis 연결 영구 실패).
+     *
+     * @see #updateAllMemberScores() 이 메서드를 호출하는 상위 메서드.
+     * @see MemberScoreInfo 재시도 대상 모델 클래스.
+     */
+    private void retryFailedUpdates(ConcurrentLinkedQueue<MemberScoreInfo> failedUpdates) {
+        int maxRetries = 3;
+
+        failedUpdates.parallelStream().forEach(score -> {
+            AtomicInteger retryCount = new AtomicInteger(0); // 각 score별 독립 AtomicInteger 설정
+            boolean success = false; // 성공 및 실패 여부를 저장할 boolean 변수, false로 초기화
+
+            while (retryCount.get() < maxRetries && !success) {
+                try {
+                    saveMemberScoreToRedis(score.getMemberId(), score.getScore());
+                    success = true;
+                    log.info("[SCORE RETRY] {} 멤버의 score를 Redis에 재시도 성공 (시도 횟수: {})",
+                            score.getMemberId(), retryCount.get() + 1);  // +1로 실제 시도 횟수 업데이트
+                } catch (Exception e) {
+                    retryCount.incrementAndGet();  // 실패 시 카운트 증가
+                    log.error("[SCORE RETRY ERROR] {} 멤버의 score 재시도 실패 (현재 시도: {}, 오류: {})",
+                            score.getMemberId(), retryCount.get(), e.getMessage());
+                }
+            }
+
+            if (!success) {
+                log.error("[SCORE RETRY FAILED] {} 멤버의 업데이트를 최종 실패 (총 시도: {})",
+                        score.getMemberId(), maxRetries);
+                // TODO: 영구 실패 처리 (DB에 실패 로그 저장, 슬랙 알림 전송, 또는 별도 큐로 이동 등)
+            }
+        });
     }
 }

--- a/src/main/java/com/grow/member_service/member/domain/model/MemberScoreInfo.java
+++ b/src/main/java/com/grow/member_service/member/domain/model/MemberScoreInfo.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 /**
- * <h2>멤버 점수 DTO</h2>
+ * <h2>멤버 점수 VO</h2>
  *
  * <p>이 클래스는 멤버의 ID와 신뢰 점수를 전달하기 위한 Value Object 입니다.
  * 데이터베이스 조회 결과를 캡슐화하여 서비스 계층 ScoreUpdateService 에서 Redis 업데이트 시 활용됩니다.</p>
@@ -20,11 +20,29 @@ import lombok.ToString;
  *   <li>용도: MemberRepository의 Projection 결과를 매핑하여 처리 (Projection -> 인프라 레이어의 DTO)</li>
  * </ol>
  */
-@Getter
-@ToString
-@AllArgsConstructor
 public class MemberScoreInfo {
 
-    private Long memberId;
-    private Double score;
+    private final Long memberId;
+    private final Double score;
+
+    public MemberScoreInfo(Long memberId, Double score) {
+        this.memberId = memberId;
+        this.score = score;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+
+    public Double getScore() {
+        return score;
+    }
+
+    @Override
+    public String toString() {
+        return "MemberScoreInfo{" +
+                "memberId=" + memberId +
+                ", score=" + score +
+                '}';
+    }
 }

--- a/src/main/java/com/grow/member_service/member/domain/model/MemberScoreInfo.java
+++ b/src/main/java/com/grow/member_service/member/domain/model/MemberScoreInfo.java
@@ -1,4 +1,4 @@
-package com.grow.member_service.member.application.dto;
+package com.grow.member_service.member.domain.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -7,8 +7,8 @@ import lombok.ToString;
 /**
  * <h2>멤버 점수 DTO</h2>
  *
- * <p>이 클래스는 멤버의 ID와 신뢰 점수를 전달하기 위한 데이터 전송 객체(DTO)입니다.
- * 데이터베이스 조회 결과를 캡슐화하여 서비스 계층 ScoreUpdateService에서 Redis 업데이트 시 활용됩니다.</p>
+ * <p>이 클래스는 멤버의 ID와 신뢰 점수를 전달하기 위한 Value Object 입니다.
+ * 데이터베이스 조회 결과를 캡슐화하여 서비스 계층 ScoreUpdateService 에서 Redis 업데이트 시 활용됩니다.</p>
  *
  * <ol>
  *   <li>필드:
@@ -23,7 +23,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @AllArgsConstructor
-public class MemberScoreDto {
+public class MemberScoreInfo {
 
     private Long memberId;
     private Double score;

--- a/src/main/java/com/grow/member_service/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/grow/member_service/member/domain/repository/MemberRepository.java
@@ -3,7 +3,7 @@ package com.grow.member_service.member.domain.repository;
 import java.util.List;
 import java.util.Optional;
 
-import com.grow.member_service.member.application.dto.MemberScoreDto;
+import com.grow.member_service.member.domain.model.MemberScoreInfo;
 import com.grow.member_service.member.domain.model.Member;
 import com.grow.member_service.member.domain.model.enums.Platform;
 
@@ -16,5 +16,5 @@ public interface MemberRepository {
     Optional<Member> findByPlatformId(String platformId, Platform platform);
     Optional<Object> findByNickname(String nickname);
     List<Member> findAllExcept(Long exceptMemberId);
-    List<MemberScoreDto> findAllScore();
+    List<MemberScoreInfo> findAllScore();
 }

--- a/src/main/java/com/grow/member_service/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/grow/member_service/member/domain/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package com.grow.member_service.member.domain.repository;
 import java.util.List;
 import java.util.Optional;
 
+import com.grow.member_service.member.application.dto.MemberScoreDto;
 import com.grow.member_service.member.domain.model.Member;
 import com.grow.member_service.member.domain.model.enums.Platform;
 
@@ -12,9 +13,8 @@ import com.grow.member_service.member.domain.model.enums.Platform;
 public interface MemberRepository {
     Member save(Member member);
     Optional<Member> findById(Long memberId);
-    Optional<Member> findByEmail(String email);
     Optional<Member> findByPlatformId(String platformId, Platform platform);
-    List<Member> findAll();
     Optional<Object> findByNickname(String nickname);
     List<Member> findAllExcept(Long exceptMemberId);
+    List<MemberScoreDto> findAllScore();
 }

--- a/src/main/java/com/grow/member_service/member/infra/dto/MemberScoreProjection.java
+++ b/src/main/java/com/grow/member_service/member/infra/dto/MemberScoreProjection.java
@@ -1,0 +1,24 @@
+package com.grow.member_service.member.infra.dto;
+
+/**
+ * <h2>멤버 점수 프로젝션 인터페이스</h2>
+ *
+ * <p>이 인터페이스는 데이터베이스 쿼리에서 멤버의 ID와 신뢰 점수를 Projection하기 위해 사용됩니다.
+ * QueryDSL이나 JPA 쿼리에서 필요한 필드만 추출하여 성능을 최적화합니다.
+ * MemberRepository의 findAllScore() 메서드에서 DTO로 매핑되어 사용됩니다.</p>
+ *
+ * <ol>
+ *   <li>용도: 데이터베이스에서 memberId와 score 필드를 직접 매핑</li>
+ *   <li>메서드:
+ *       <ul>
+ *         <li>getMemberId(): 멤버의 고유 ID 반환 (Long 타입)</li>
+ *         <li>getScore(): 멤버의 신뢰 점수 반환 (Double 타입)</li>
+ *       </ul>
+ *   </li>
+ *   <li>연관: MemberScoreDto로 변환되어 ScoreUpdateService 에서 Redis 업데이트에 활용</li>
+ * </ol>
+ */
+public interface MemberScoreProjection {
+    Long getMemberId();
+    Double getScore();
+}

--- a/src/main/java/com/grow/member_service/member/infra/persistence/repository/MemberJpaRepository.java
+++ b/src/main/java/com/grow/member_service/member/infra/persistence/repository/MemberJpaRepository.java
@@ -4,15 +4,16 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.grow.member_service.member.infra.dto.MemberScoreProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.grow.member_service.member.domain.model.enums.Platform;
 import com.grow.member_service.member.infra.persistence.entity.MemberJpaEntity;
 
 public interface MemberJpaRepository extends JpaRepository<MemberJpaEntity, Long> {
-    Optional<MemberJpaEntity> findByEmail(String email);
 	Optional<MemberJpaEntity> findByPlatformIdAndPlatform(String platformId, Platform platform);
 	List<MemberJpaEntity> findAllByWithdrawalAtBefore(LocalDateTime threshold);
 	Optional<MemberJpaEntity> findByNickname(String nickname);
 	List<MemberJpaEntity> findByMemberIdNot(Long memberId);
+	List<MemberScoreProjection> findAllBy(); // memberId와 score를 가진 dto 리스트 반환
 }

--- a/src/main/java/com/grow/member_service/member/infra/persistence/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/grow/member_service/member/infra/persistence/repository/MemberRepositoryImpl.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import com.grow.member_service.member.application.dto.MemberScoreDto;
+import com.grow.member_service.member.infra.dto.MemberScoreProjection;
 import org.springframework.stereotype.Repository;
 
 import com.grow.member_service.member.domain.model.Member;
@@ -35,22 +37,9 @@ public class MemberRepositoryImpl implements MemberRepository {
     }
 
     @Override
-    public Optional<Member> findByEmail(String email) {
-        return memberJpaRepository.findByEmail(email)
-            .map(memberMapper::toDomain);
-    }
-
-    @Override
     public Optional<Member> findByPlatformId(String platformId, Platform platform) {
         return memberJpaRepository.findByPlatformIdAndPlatform(platformId, platform)
             .map(memberMapper::toDomain);
-    }
-
-    @Override
-    public List<Member> findAll() {
-        return memberJpaRepository.findAll().stream()
-            .map(memberMapper::toDomain)
-            .collect(Collectors.toList());
     }
 
     @Override
@@ -65,5 +54,24 @@ public class MemberRepositoryImpl implements MemberRepository {
             .stream()
             .map(memberMapper::toDomain)
             .toList();
+    }
+
+    /**
+     * 모든 멤버의 점수를 조회하여 MemberScoreDto 리스트로 반환합니다.
+     *
+     * <p>이 메서드는 데이터베이스에서 MemberScoreProjection을 조회한 후,
+     * 이를 MemberScoreDto로 변환하여 반환합니다. Projection을 사용해 필요한 필드만 효율적으로 가져옵니다.</p>
+     *
+     * @return MemberScoreDto 리스트 (각 DTO는 memberId와 score를 포함)
+     */
+    @Override
+    public List<MemberScoreDto> findAllScore() {
+        List<MemberScoreProjection> projections = memberJpaRepository.findAllBy();  // Projection 조회
+        return projections.stream()
+                .map(p -> new MemberScoreDto(
+                        p.getMemberId(),
+                        p.getScore()
+                ))// // Projection -> DTO 변환
+                .toList();
     }
 }

--- a/src/main/java/com/grow/member_service/member/infra/persistence/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/grow/member_service/member/infra/persistence/repository/MemberRepositoryImpl.java
@@ -2,9 +2,8 @@ package com.grow.member_service.member.infra.persistence.repository;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
-import com.grow.member_service.member.application.dto.MemberScoreDto;
+import com.grow.member_service.member.domain.model.MemberScoreInfo;
 import com.grow.member_service.member.infra.dto.MemberScoreProjection;
 import org.springframework.stereotype.Repository;
 
@@ -65,10 +64,10 @@ public class MemberRepositoryImpl implements MemberRepository {
      * @return MemberScoreDto 리스트 (각 DTO는 memberId와 score를 포함)
      */
     @Override
-    public List<MemberScoreDto> findAllScore() {
+    public List<MemberScoreInfo> findAllScore() {
         List<MemberScoreProjection> projections = memberJpaRepository.findAllBy();  // Projection 조회
         return projections.stream()
-                .map(p -> new MemberScoreDto(
+                .map(p -> new MemberScoreInfo(
                         p.getMemberId(),
                         p.getScore()
                 ))// // Projection -> DTO 변환

--- a/src/test/java/com/grow/member_service/member/application/service/ScoreUpdateServiceTest.java
+++ b/src/test/java/com/grow/member_service/member/application/service/ScoreUpdateServiceTest.java
@@ -1,0 +1,89 @@
+package com.grow.member_service.member.application.service;
+
+import com.grow.member_service.member.domain.model.enums.Platform;
+import com.grow.member_service.member.infra.persistence.entity.MemberJpaEntity;
+import com.grow.member_service.member.infra.persistence.repository.MemberJpaRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@SpringBootTest
+class ScoreUpdateServiceTest {
+
+    @Autowired
+    private ScoreUpdateService scoreUpdateService;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private RedisTemplate<String, Double> customDoubleRedisTemplate;
+
+    @Autowired
+    private MemberJpaRepository memberJpaRepository;
+
+    private static final String TRUST_KEY = "member:trust:score:";
+
+    MemberJpaEntity member1;
+    MemberJpaEntity member2;
+
+    @BeforeEach
+    void setUp() {
+        // Redis 초기화
+        customDoubleRedisTemplate.getConnectionFactory().getConnection().flushDb();
+        memberJpaRepository.deleteAll();
+
+        // EntityManager로 멤버 엔티티 저장
+        member1 = MemberJpaEntity.builder()
+                .email("test1@example.com")
+                .nickname("test1")
+                .platform(Platform.GOOGLE)  // enums.Platform 가정
+                .platformId("plat1")
+                .createAt(LocalDateTime.now())
+                .totalPoint(0)
+                .score(85.5)
+                .build();
+        entityManager.persist(member1);
+
+        member2 = MemberJpaEntity.builder()
+                .email("test2@example.com")
+                .nickname("test2")
+                .platform(Platform.GOOGLE)
+                .platformId("plat2")
+                .totalPoint(0)
+                .createAt(LocalDateTime.now())
+                .score(92.0)
+                .build();
+        entityManager.persist(member2);
+
+        entityManager.flush();  // 즉시 DB 반영
+    }
+
+    @Test
+    @DisplayName("updateAllMemberScores(): 모든 멤버의 score를 업데이트하는 테스트 코드")
+    void updateAllMemberScores_shouldUpdateRedis_whenMembersExist() {
+        // Given: 존재하는 멤버들의 score가 DB에 저장되어 있음
+
+        // When: 서비스 메서드 호출
+        scoreUpdateService.updateAllMemberScores();
+
+        // Then: Redis에 score가 제대로 저장되었는지 확인
+        Double score1 = customDoubleRedisTemplate.opsForValue().get(TRUST_KEY + member1.getMemberId());
+        assertThat(score1).isEqualTo(85.5);
+
+        Double score2 = customDoubleRedisTemplate.opsForValue().get(TRUST_KEY + member2.getMemberId());
+        assertThat(score2).isEqualTo(92.0);
+    }
+}


### PR DESCRIPTION

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)

+ 📸 Screenshot or Test Result

<img width="1109" height="135" alt="스크린샷 2025-07-28 오후 10 56 46" src="https://github.com/user-attachments/assets/4acf3b8f-540b-405d-92f6-39ddb61eb36b" />
<img width="605" height="120" alt="스크린샷 2025-07-28 오후 10 56 52" src="https://github.com/user-attachments/assets/ac705311-3b97-48b9-84b6-b1d7247d25eb" />

- 테스트 코드 통과 완료했습니다. 

+ 아마 여기 CI 에는 redis 가 추가되지 않아서 빌드가 안 돌 수 있을 것 같은데 그 부분은 CI 에 추가해서 반영해 두겠습니다 
프로젝션 객체는 인프라 레이어에서 가져온 것이기 때문에 별도의 DTO 를 따로 만들어서 사용해야 한다고 하던데 (클린 아키텍쳐 기준)
늘 생각하지만 정말 대단한 구현입니다 