### PR TITLE
✨ feat: 구독 갱신 기능 추가 및 이력 저장 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -128,6 +128,9 @@ dependencies {
 
 	// redis cache
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis:3.5.3'
+
+	// Quartz
+	implementation 'org.springframework.boot:spring-boot-starter-quartz'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grow/member_service/global/config/QuartzConfig.java
+++ b/src/main/java/com/grow/member_service/global/config/QuartzConfig.java
@@ -1,0 +1,62 @@
+package com.grow.member_service.config;
+
+import org.quartz.CronScheduleBuilder;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+
+import com.grow.member_service.history.subscription.infra.batch.SubscriptionExpiryJob;
+import com.grow.member_service.history.subscription.infra.batch.SubscriptionExpiryJobListener;
+
+@Configuration
+public class QuartzConfig {
+
+	private final SubscriptionExpiryJobListener expiryListener;
+
+	public QuartzConfig(SubscriptionExpiryJobListener expiryListener) {
+		this.expiryListener = expiryListener;
+	}
+
+	/** 구독 만료 JobDetail Bean 등록 */
+	@Bean
+	public JobDetail subscriptionExpiryJobDetail() {
+		return JobBuilder.newJob(SubscriptionExpiryJob.class)
+			.withIdentity("subscriptionExpiryJob")
+			.storeDurably()
+			// 재시도 카운트: 최대 3회
+			.usingJobData("retryCount", 0)
+			.usingJobData("maxRetry", 3)
+			.build();
+	}
+
+	/** 매일 0시 SubscriptionExpiryJob Trigger (놓친 스케줄 즉시 실행) */
+	@Bean
+	public Trigger subscriptionExpiryTrigger(JobDetail subscriptionExpiryJobDetail) {
+		CronScheduleBuilder schedule = CronScheduleBuilder
+			.cronSchedule("0 0 0 * * ?")
+			.withMisfireHandlingInstructionFireAndProceed(); // 미스파이어 발생 시 즉시 실행
+
+		return TriggerBuilder.newTrigger()
+			.forJob(subscriptionExpiryJobDetail)
+			.withIdentity("subscriptionExpiryTrigger")
+			.withSchedule(schedule)
+			.build();
+	}
+
+	/** Quartz Scheduler 설정 (JobDetail, Trigger, Global Listener) */
+	@Bean
+	public SchedulerFactoryBean schedulerFactoryBean(
+		JobDetail subscriptionExpiryJobDetail,
+		Trigger subscriptionExpiryTrigger
+	) {
+		SchedulerFactoryBean factory = new SchedulerFactoryBean();
+		factory.setJobDetails(subscriptionExpiryJobDetail);
+		factory.setTriggers(subscriptionExpiryTrigger);
+		factory.setGlobalJobListeners(expiryListener);
+		return factory;
+	}
+}

--- a/src/main/java/com/grow/member_service/global/config/QuartzConfig.java
+++ b/src/main/java/com/grow/member_service/global/config/QuartzConfig.java
@@ -21,33 +21,31 @@ public class QuartzConfig {
 		this.expiryListener = expiryListener;
 	}
 
-	/** 구독 만료 JobDetail Bean 등록 */
+	/** 구독 만료 JobDetail Bean */
 	@Bean
 	public JobDetail subscriptionExpiryJobDetail() {
 		return JobBuilder.newJob(SubscriptionExpiryJob.class)
 			.withIdentity("subscriptionExpiryJob")
 			.storeDurably()
-			// 재시도 카운트: 최대 3회
 			.usingJobData("retryCount", 0)
 			.usingJobData("maxRetry", 3)
 			.build();
 	}
 
-	/** 매일 0시 SubscriptionExpiryJob Trigger (놓친 스케줄 즉시 실행) */
+	/** 매일 0시 구독만료 실행 Trigger */
 	@Bean
 	public Trigger subscriptionExpiryTrigger(JobDetail subscriptionExpiryJobDetail) {
-		CronScheduleBuilder schedule = CronScheduleBuilder
-			.cronSchedule("0 0 0 * * ?")
-			.withMisfireHandlingInstructionFireAndProceed(); // 미스파이어 발생 시 즉시 실행
-
 		return TriggerBuilder.newTrigger()
 			.forJob(subscriptionExpiryJobDetail)
 			.withIdentity("subscriptionExpiryTrigger")
-			.withSchedule(schedule)
+			.withSchedule(
+				CronScheduleBuilder.cronSchedule("0 0 0 * * ?")
+					.withMisfireHandlingInstructionFireAndProceed()
+			)
 			.build();
 	}
 
-	/** Quartz Scheduler 설정 (JobDetail, Trigger, Global Listener) */
+	/** SchedulerFactoryBean 설정: JobDetail, Trigger, Global Listener 등록 */
 	@Bean
 	public SchedulerFactoryBean schedulerFactoryBean(
 		JobDetail subscriptionExpiryJobDetail,

--- a/src/main/java/com/grow/member_service/history/subscription/application/service/SubscriptionHistoryApplicationService.java
+++ b/src/main/java/com/grow/member_service/history/subscription/application/service/SubscriptionHistoryApplicationService.java
@@ -12,6 +12,7 @@ import com.grow.member_service.global.exception.ErrorCode;
 import com.grow.member_service.history.subscription.application.dto.SubscriptionHistoryResponse;
 import com.grow.member_service.history.subscription.domain.model.SubscriptionHistory;
 import com.grow.member_service.history.subscription.domain.repository.SubscriptionHistoryRepository;
+import com.grow.member_service.history.subscription.infra.persistence.entity.SubscriptionStatus;
 
 import lombok.RequiredArgsConstructor;
 
@@ -45,5 +46,26 @@ public class SubscriptionHistoryApplicationService {
 		// Clock.systemDefaultZone()을 넘겨서 startAt=now, endAt=now+1month
 		SubscriptionHistory history = new SubscriptionHistory(memberId, Clock.systemDefaultZone());
 		repository.save(history);
+	}
+
+	/**
+	 * Quartz 에서 호출할 만료 처리 메서드
+	 */
+	@Transactional
+	public void recordExpiry(
+		Long memberId,
+		java.time.LocalDateTime startAt,
+		java.time.LocalDateTime endAt,
+		java.time.LocalDateTime changeAt
+	) {
+		SubscriptionHistory expired = new SubscriptionHistory(
+			null,
+			memberId,
+			SubscriptionStatus.EXPIRED,
+			startAt,
+			endAt,
+			changeAt
+		);
+		repository.save(expired);
 	}
 }

--- a/src/main/java/com/grow/member_service/history/subscription/application/service/SubscriptionHistoryApplicationService.java
+++ b/src/main/java/com/grow/member_service/history/subscription/application/service/SubscriptionHistoryApplicationService.java
@@ -1,5 +1,6 @@
 package com.grow.member_service.history.subscription.application.service;
 
+import java.time.Clock;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -9,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.grow.member_service.common.exception.SubscriptionHistoryException;
 import com.grow.member_service.global.exception.ErrorCode;
 import com.grow.member_service.history.subscription.application.dto.SubscriptionHistoryResponse;
+import com.grow.member_service.history.subscription.domain.model.SubscriptionHistory;
 import com.grow.member_service.history.subscription.domain.repository.SubscriptionHistoryRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -33,5 +35,15 @@ public class SubscriptionHistoryApplicationService {
 		}
 
 		return list;
+	}
+
+	/**
+	 * 구독 갱신: ACTIVE 상태로 오늘부터 1개월 연장된 이력을 하나 추가 저장
+	 */
+	@Transactional
+	public void recordSubscriptionRenewal(Long memberId) {
+		// Clock.systemDefaultZone()을 넘겨서 startAt=now, endAt=now+1month
+		SubscriptionHistory history = new SubscriptionHistory(memberId, Clock.systemDefaultZone());
+		repository.save(history);
 	}
 }

--- a/src/main/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJob.java
+++ b/src/main/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJob.java
@@ -1,0 +1,44 @@
+package com.grow.member_service.history.subscription.infra.batch;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.stereotype.Component;
+
+import com.grow.member_service.history.subscription.application.service.SubscriptionHistoryApplicationService;
+import com.grow.member_service.history.subscription.infra.persistence.entity.SubscriptionHistoryJpaEntity;
+import com.grow.member_service.history.subscription.infra.persistence.entity.SubscriptionStatus;
+import com.grow.member_service.history.subscription.infra.persistence.repository.SubscriptionHistoryJpaRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubscriptionExpiryJob implements Job {
+
+	private final SubscriptionHistoryJpaRepository historyJpaRepository;
+	private final SubscriptionHistoryApplicationService historyService;
+
+	@Override
+	public void execute(JobExecutionContext context) throws JobExecutionException {
+		LocalDateTime now = LocalDateTime.now();
+		List<SubscriptionHistoryJpaEntity> expiredList =
+			historyJpaRepository.findExpiredBefore(SubscriptionStatus.ACTIVE, now);
+
+		for (SubscriptionHistoryJpaEntity e : expiredList) {
+			historyService.recordExpiry(
+				e.getMemberId(),
+				e.getStartAt(),
+				e.getEndAt(),
+				now
+			);
+			log.info("[구독 만료 스케줄러] 만료 처리: memberId={}, endAt={}",
+				e.getMemberId(), e.getEndAt());
+		}
+	}
+}

--- a/src/main/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJobListener.java
+++ b/src/main/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJobListener.java
@@ -1,0 +1,87 @@
+package com.grow.member_service.history.subscription.infra.batch;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.quartz.DateBuilder;
+import org.quartz.JobDataMap;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.JobKey;
+import org.quartz.Scheduler;
+import org.quartz.Trigger;
+import org.quartz.TriggerBuilder;
+import org.quartz.listeners.JobListenerSupport;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * [SubscriptionExpiry] Quartz JobListener
+ * - 성공: retryCount 초기화
+ * - 실패: retryCount < maxRetry -> 지수 백오프 + Jitter 로 재시도 스케줄링
+ *         retryCount ≥ maxRetry -> 재시도 중단
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubscriptionExpiryJobListener extends JobListenerSupport {
+
+	public static final String LISTENER_NAME = "SubscriptionExpiryListener";
+
+	private final Scheduler scheduler;
+
+	@Override
+	public String getName() {
+		return LISTENER_NAME;
+	}
+
+	@Override
+	public void jobWasExecuted(JobExecutionContext context, JobExecutionException jobException) {
+		JobKey key = context.getJobDetail().getKey();
+		JobDataMap data = context.getJobDetail().getJobDataMap();
+		int retryCount = data.getInt("retryCount");
+		int maxRetry   = data.getInt("maxRetry");
+
+		if (jobException == null) {
+			// 성공 시 retryCount 초기화
+			data.put("retryCount", 0);
+			log.info("[SubscriptionExpiry] {} 실행 성공, retryCount 초기화", key);
+			return;
+		}
+
+		// 실패 시
+		log.warn("[SubscriptionExpiry] {} 실패: {}, retryCount={}/{}",
+			key, jobException.getMessage(), retryCount, maxRetry);
+
+		if (retryCount < maxRetry) {
+			// retryCount 증가
+			int newCount = retryCount + 1;
+			data.put("retryCount", newCount);
+
+			// 지수 백오프 계산 + Jitter
+			int baseDelaySec = 60; // 기본 1분
+			long exp        = baseDelaySec * (1L << (newCount - 1));
+			int maxDelay     = (int) Math.min(exp, 3600); // 최대 1시간
+			int jitter       = ThreadLocalRandom.current().nextInt(0, baseDelaySec);
+			int delaySec     = Math.max(1, maxDelay - jitter);
+
+			Trigger retryTrigger = TriggerBuilder.newTrigger()
+				.forJob(key)
+				.usingJobData(data)
+				.startAt(DateBuilder.futureDate(delaySec, DateBuilder.IntervalUnit.SECOND))
+				.build();
+
+			try {
+				scheduler.scheduleJob(retryTrigger);
+				log.info("[SubscriptionExpiry] 재시도 예약: delay={}초, retryCount={}/{}",
+					delaySec, newCount, maxRetry);
+			} catch (Exception e) {
+				log.error("[SubscriptionExpiry] 재시도 Trigger 등록 실패: key={}", key, e);
+			}
+		} else {
+			// 최대 재시도 도달, 중단
+			log.error("[SubscriptionExpiry] 최대 재시도 횟수({}) 도달, 재시도 중단: {}", maxRetry, key);
+		}
+	}
+}

--- a/src/main/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJobListener.java
+++ b/src/main/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJobListener.java
@@ -7,7 +7,6 @@ import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.quartz.JobKey;
-import org.quartz.Scheduler;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.listeners.JobListenerSupport;
@@ -28,8 +27,6 @@ import lombok.extern.slf4j.Slf4j;
 public class SubscriptionExpiryJobListener extends JobListenerSupport {
 
 	public static final String LISTENER_NAME = "SubscriptionExpiryListener";
-
-	private final Scheduler scheduler;
 
 	@Override
 	public String getName() {
@@ -73,7 +70,7 @@ public class SubscriptionExpiryJobListener extends JobListenerSupport {
 				.build();
 
 			try {
-				scheduler.scheduleJob(retryTrigger);
+				context.getScheduler().scheduleJob(retryTrigger);
 				log.info("[SubscriptionExpiry] 재시도 예약: delay={}초, retryCount={}/{}",
 					delaySec, newCount, maxRetry);
 			} catch (Exception e) {

--- a/src/main/java/com/grow/member_service/history/subscription/infra/persistence/repository/SubscriptionHistoryJpaRepository.java
+++ b/src/main/java/com/grow/member_service/history/subscription/infra/persistence/repository/SubscriptionHistoryJpaRepository.java
@@ -1,11 +1,26 @@
 package com.grow.member_service.history.subscription.infra.persistence.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.grow.member_service.history.subscription.infra.persistence.entity.SubscriptionHistoryJpaEntity;
+import com.grow.member_service.history.subscription.infra.persistence.entity.SubscriptionStatus;
 
 public interface SubscriptionHistoryJpaRepository extends JpaRepository<SubscriptionHistoryJpaEntity, Long> {
 	List<SubscriptionHistoryJpaEntity> findAllByMemberId(Long memberId);
+
+	@Query("""
+      select e 
+      from SubscriptionHistoryJpaEntity e
+      where e.subscriptionStatus = :activeStatus
+        and e.endAt < :now
+    """)
+	List<SubscriptionHistoryJpaEntity> findExpiredBefore(
+		@Param("activeStatus") SubscriptionStatus activeStatus,
+		@Param("now") LocalDateTime now
+	);
 }

--- a/src/main/java/com/grow/member_service/history/subscription/presentation/controller/SubscriptionHistoryController.java
+++ b/src/main/java/com/grow/member_service/history/subscription/presentation/controller/SubscriptionHistoryController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,5 +32,14 @@ public class SubscriptionHistoryController {
 	) {
 		List<SubscriptionHistoryResponse> list = subscriptionHistoryApplicationService.getMySubscriptionHistories(memberId);
 		return ResponseEntity.ok(new RsData<>("200", "내 구독 이력 조회 성공", list));
+	}
+
+	@Operation(summary = "구독 갱신", description = "인증된 멤버의 구독을 1개월 연장하고 이력에 저장합니다.")
+	@PostMapping("/renew")
+	public ResponseEntity<RsData<Void>> renewSubscription(
+		@AuthenticationPrincipal Long memberId
+	) {
+		subscriptionHistoryApplicationService.recordSubscriptionRenewal(memberId);
+		return ResponseEntity.ok(new RsData<>("200", "구독 갱신 성공", null));
 	}
 }

--- a/src/test/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJobListenerTest.java
+++ b/src/test/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJobListenerTest.java
@@ -36,6 +36,7 @@ class SubscriptionExpiryJobListenerTest {
 
 		context = mock(JobExecutionContext.class);
 		when(context.getJobDetail()).thenReturn(jobDetail);
+		when(context.getScheduler()).thenReturn(scheduler);
 	}
 
 	@Test

--- a/src/test/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJobListenerTest.java
+++ b/src/test/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJobListenerTest.java
@@ -1,0 +1,84 @@
+package com.grow.member_service.history.subscription.infra.batch;
+
+import static org.mockito.Mockito.*;
+
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.quartz.*;
+
+class SubscriptionExpiryJobListenerTest {
+
+	@Mock
+	private Scheduler scheduler;
+
+	@InjectMocks
+	private SubscriptionExpiryJobListener listener;
+
+	private JobKey jobKey;
+	private JobDataMap dataMap;
+	private JobDetail jobDetail;
+	private JobExecutionContext context;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+		jobKey = new JobKey("subscriptionExpiryJob");
+		dataMap = new JobDataMap();
+		dataMap.put("retryCount", 0);
+		dataMap.put("maxRetry", 2);
+
+		jobDetail = mock(JobDetail.class);
+		when(jobDetail.getKey()).thenReturn(jobKey);
+		when(jobDetail.getJobDataMap()).thenReturn(dataMap);
+
+		context = mock(JobExecutionContext.class);
+		when(context.getJobDetail()).thenReturn(jobDetail);
+	}
+
+	@Test
+	void jobWasExecuted_onSuccess_shouldResetRetryCount() {
+		// when: 성공 (jobException == null)
+		listener.jobWasExecuted(context, null);
+
+		// then
+		assert dataMap.getInt("retryCount") == 0;
+		// scheduler should not be called
+		verifyNoInteractions(scheduler);
+	}
+
+	@Test
+	void jobWasExecuted_onFailureUnderMaxRetry_shouldScheduleRetry() throws SchedulerException {
+		// given: simulate first failure
+		JobExecutionException ex = new JobExecutionException("fail");
+		// retryCount starts at 0, maxRetry=2
+
+		// when
+		listener.jobWasExecuted(context, ex);
+
+		// then retryCount incremented
+		assert dataMap.getInt("retryCount") == 1;
+		// should schedule one retry trigger
+		verify(scheduler).scheduleJob(argThat(trigger ->
+			trigger.getJobKey().equals(jobKey) &&
+				trigger.getStartTime().after(new Date())
+		));
+	}
+
+	@Test
+	void jobWasExecuted_onFailureAtMaxRetry_shouldNotScheduleRetryAgain() throws SchedulerException {
+		// given: already at maxRetry
+		dataMap.put("retryCount", 2);
+		JobExecutionException ex = new JobExecutionException("fail again");
+
+		// when
+		listener.jobWasExecuted(context, ex);
+
+		// then retryCount remains at maxRetry
+		assert dataMap.getInt("retryCount") == 2;
+		// no additional scheduling
+		verifyNoInteractions(scheduler);
+	}
+}

--- a/src/test/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJobTest.java
+++ b/src/test/java/com/grow/member_service/history/subscription/infra/batch/SubscriptionExpiryJobTest.java
@@ -1,0 +1,75 @@
+package com.grow.member_service.history.subscription.infra.batch;
+
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.quartz.JobExecutionContext;
+
+import com.grow.member_service.history.subscription.application.service.SubscriptionHistoryApplicationService;
+import com.grow.member_service.history.subscription.infra.persistence.entity.SubscriptionHistoryJpaEntity;
+import com.grow.member_service.history.subscription.infra.persistence.entity.SubscriptionStatus;
+import com.grow.member_service.history.subscription.infra.persistence.repository.SubscriptionHistoryJpaRepository;
+
+class SubscriptionExpiryJobTest {
+
+	@Mock
+	private SubscriptionHistoryJpaRepository jpaRepo;
+
+	@Mock
+	private SubscriptionHistoryApplicationService historyService;
+
+	@InjectMocks
+	private SubscriptionExpiryJob job;
+
+	@BeforeEach
+	void setUp() {
+		MockitoAnnotations.openMocks(this);
+	}
+
+	@Test
+	void execute_whenThereAreExpiredSubscriptions_shouldCallRecordExpiry() throws Exception {
+		// given
+		LocalDateTime now = LocalDateTime.now();
+		SubscriptionHistoryJpaEntity e1 = SubscriptionHistoryJpaEntity.builder()
+			.memberId(1L)
+			.subscriptionStatus(SubscriptionStatus.ACTIVE)
+			.startAt(now.minusMonths(2))
+			.endAt(now.minusDays(1))
+			.changeAt(null)
+			.build();
+		SubscriptionHistoryJpaEntity e2 = SubscriptionHistoryJpaEntity.builder()
+			.memberId(2L)
+			.subscriptionStatus(SubscriptionStatus.ACTIVE)
+			.startAt(now.minusMonths(1))
+			.endAt(now.minusHours(1))
+			.changeAt(null)
+			.build();
+		when(jpaRepo.findExpiredBefore(eq(SubscriptionStatus.ACTIVE), any(LocalDateTime.class)))
+			.thenReturn(List.of(e1, e2));
+
+		// when
+		job.execute(mock(JobExecutionContext.class));
+
+		// then
+		verify(historyService).recordExpiry(eq(1L), eq(e1.getStartAt()), eq(e1.getEndAt()), any(LocalDateTime.class));
+		verify(historyService).recordExpiry(eq(2L), eq(e2.getStartAt()), eq(e2.getEndAt()), any(LocalDateTime.class));
+		verifyNoMoreInteractions(historyService);
+	}
+
+	@Test
+	void execute_whenNoExpiredSubscriptions_shouldNotCallRecordExpiry() throws Exception {
+		// given
+		when(jpaRepo.findExpiredBefore(any(), any())).thenReturn(List.of());
+
+		// when
+		job.execute(mock(JobExecutionContext.class));
+
+		// then
+		verifyNoInteractions(historyService);
+	}
+}

--- a/src/test/java/com/grow/member_service/member/application/service/ScoreUpdateServiceUnitTest.java
+++ b/src/test/java/com/grow/member_service/member/application/service/ScoreUpdateServiceUnitTest.java
@@ -1,0 +1,126 @@
+package com.grow.member_service.member.application.service;
+
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import com.grow.member_service.member.domain.model.MemberScoreInfo;
+import com.grow.member_service.member.domain.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class ScoreUpdateServiceUnitTest {
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@Mock
+	RedisTemplate<String, Double> redisTemplate;
+
+	@Mock
+	ValueOperations<String, Double> valueOps;
+
+	ScoreUpdateService service;
+
+	private static final String TRUST_KEY = ScoreUpdateService.TRUST_KEY;
+	private final Long MEMBER_ID = 999L;
+
+	@BeforeEach
+	void init() {
+		// 직접 생성자를 통해 주입
+		service = new ScoreUpdateService(memberRepository, redisTemplate);
+		// opsForValue() 가 valueOps 를 반환하도록 설정
+		given(redisTemplate.opsForValue()).willReturn(valueOps);
+	}
+
+	@Test
+	@DisplayName("saveMemberScoreToRedis: 기존 값 없으면 SET 호출")
+	void saveMemberScore_new_shouldSet() {
+		given(valueOps.get(TRUST_KEY + MEMBER_ID)).willReturn(null);
+
+		service.saveMemberScoreToRedis(MEMBER_ID, 42.0);
+
+		then(valueOps).should().set(TRUST_KEY + MEMBER_ID, 42.0);
+	}
+
+	@Test
+	@DisplayName("saveMemberScoreToRedis: 기존 값과 같으면 SET 미호출")
+	void saveMemberScore_same_shouldSkip() {
+		given(valueOps.get(TRUST_KEY + MEMBER_ID)).willReturn(7.5);
+
+		service.saveMemberScoreToRedis(MEMBER_ID, 7.5);
+
+		then(valueOps).should(never()).set(anyString(), anyDouble());
+	}
+
+	@Test
+	@DisplayName("saveMemberScoreToRedis: 기존 값 다르면 SET 호출")
+	void saveMemberScore_diff_shouldUpdate() {
+		given(valueOps.get(TRUST_KEY + MEMBER_ID)).willReturn(1.1);
+
+		service.saveMemberScoreToRedis(MEMBER_ID, 9.9);
+
+		then(valueOps).should().set(TRUST_KEY + MEMBER_ID, 9.9);
+	}
+
+	@Test
+	@DisplayName("retryFailedUpdates: 첫 시도 성공 시 1회만 SET 호출")
+	void retryFailed_firstSuccess() throws Exception {
+		MemberScoreInfo info = new MemberScoreInfo(MEMBER_ID, 3.14);
+		ConcurrentLinkedQueue<MemberScoreInfo> q = new ConcurrentLinkedQueue<>(List.of(info));
+
+		// 전체 호출이 곧 valueOps.set() 을 실행 → 첫 시도 성공
+		var m = ScoreUpdateService.class
+			.getDeclaredMethod("retryFailedUpdates", ConcurrentLinkedQueue.class);
+		m.setAccessible(true);
+		m.invoke(service, q);
+
+		then(valueOps).should(times(1)).set(TRUST_KEY + MEMBER_ID, 3.14);
+	}
+
+	@Test
+	@DisplayName("retryFailedUpdates: 모두 실패 시 3회 SET 호출")
+	void retryFailed_allFail() throws Exception {
+		MemberScoreInfo info = new MemberScoreInfo(MEMBER_ID, 2.71);
+		ConcurrentLinkedQueue<MemberScoreInfo> q = new ConcurrentLinkedQueue<>(List.of(info));
+
+		// saveMemberScoreToRedis 내부에서 valueOps.set() → 모두 예외
+		willThrow(new RuntimeException("boom"))
+			.given(valueOps).set(TRUST_KEY + MEMBER_ID, 2.71);
+
+		var m = ScoreUpdateService.class
+			.getDeclaredMethod("retryFailedUpdates", ConcurrentLinkedQueue.class);
+		m.setAccessible(true);
+		m.invoke(service, q);
+
+		then(valueOps).should(times(3)).set(TRUST_KEY + MEMBER_ID, 2.71);
+	}
+
+	@Test
+	@DisplayName("updateAllMemberScores: 실패 2회 후 3회차 성공")
+	void updateAllMemberScores_retryScenario() {
+		MemberScoreInfo info = new MemberScoreInfo(MEMBER_ID, 5.55);
+		given(memberRepository.findAllScore()).willReturn(List.of(info));
+
+		AtomicInteger cnt = new AtomicInteger();
+		// 첫 두 번은 예외, 세 번째는 정상 동작
+		doAnswer(inv -> {
+			if (cnt.incrementAndGet() < 3) throw new RuntimeException("err");
+			return null; // set 성공
+		}).when(valueOps).set(TRUST_KEY + MEMBER_ID, 5.55);
+
+		service.updateAllMemberScores();
+
+		then(valueOps).should(times(3)).set(TRUST_KEY + MEMBER_ID, 5.55);
+	}
+}


### PR DESCRIPTION
## 🔍 Title(필수)
#25 


+ 📸 Screenshot or Test Result
<img width="394" height="178" alt="image" src="https://github.com/user-attachments/assets/dab26c80-c462-4dd1-8d10-12593534efa3" />


## 🔗 Related Issues(필수)
Closes #25

## 📝 Note (주의 사항)
결제 서비스에 새로 플랜 넣던 중 멤버 서비스에 구독 갱신 기능이 없는 것 같아서 급하게 추가했습니다. 
쿼츠 기반의 구독 만료 스케줄러 및 재시도 로직도 구현했습니다.
- /api/subscriptions/me 엔드포인트로 구독 이력 조회
- SubscriptionExpiryJob 매일 자정 실행
- SubscriptionExpiryJobListener 로 지수 백오프 재시도


추가로 자코코 테스트가 통과하지 못해서.. ScoreService 재시도 로직 단위 테스트 추가했습니다!


