### PR TITLE
✨ feat: 포인트 적립 및 차감 시 알림 이벤트 발행 기능 추가

### DIFF
--- a/src/main/java/com/grow/member_service/history/point/application/dto/PointHistoryResponse.java
+++ b/src/main/java/com/grow/member_service/history/point/application/dto/PointHistoryResponse.java
@@ -10,15 +10,18 @@ public class PointHistoryResponse {
 	private final Integer amount;
 	private final String content;
 	private final LocalDateTime addAt;
+	private final Long balanceAfter;
 
 	public PointHistoryResponse(Long pointHistoryId,
 		Integer amount,
 		String content,
-		LocalDateTime addAt) {
+		LocalDateTime addAt,
+		Long balanceAfter) {
 		this.pointHistoryId = pointHistoryId;
 		this.amount = amount;
 		this.content = content;
 		this.addAt = addAt;
+		this.balanceAfter = balanceAfter;
 	}
 
 	public static PointHistoryResponse fromDomain(com.grow.member_service.history.point.domain.model.PointHistory ph) {
@@ -26,7 +29,8 @@ public class PointHistoryResponse {
 			ph.getPointHistoryId(),
 			ph.getAmount(),
 			ph.getContent(),
-			ph.getAddAt()
+			ph.getAddAt(),
+			ph.getBalanceAfter()
 		);
 	}
 }

--- a/src/main/java/com/grow/member_service/history/point/application/event/PointNotificationEvent.java
+++ b/src/main/java/com/grow/member_service/history/point/application/event/PointNotificationEvent.java
@@ -1,0 +1,19 @@
+package com.grow.member_service.history.point.application.event;
+
+import java.time.LocalDateTime;
+
+import com.grow.member_service.history.point.domain.model.enums.PointActionType;
+import com.grow.member_service.history.point.domain.model.enums.SourceType;
+
+public record PointNotificationEvent(
+	Long pointHistoryId,
+	Long memberId,
+	int amount, // 적립은 양수, 차감은 음수
+	long balanceAfter, // 거래 후 잔액
+	PointActionType actionType,
+	SourceType sourceType,
+	String sourceId,
+	String content,
+	LocalDateTime occurredAt,
+	String dedupKey         // 멱등키
+) {}

--- a/src/main/java/com/grow/member_service/history/point/application/event/PointNotificationEventHandler.java
+++ b/src/main/java/com/grow/member_service/history/point/application/event/PointNotificationEventHandler.java
@@ -1,0 +1,68 @@
+package com.grow.member_service.history.point.application.event;
+
+import static org.springframework.transaction.event.TransactionPhase.*;
+
+import java.time.Duration;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import com.grow.member_service.member.infra.client.MemberNotificationClient;
+import com.grow.member_service.member.infra.client.dto.MemberNotificationRequest;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PointNotificationEventHandler {
+
+	private final MemberNotificationClient notificationClient;
+	private final ObjectProvider<StringRedisTemplate> redisProvider;
+
+	private static final Duration DEDUPE_TTL = Duration.ofHours(24);
+
+	@TransactionalEventListener(phase = AFTER_COMMIT)
+	public void on(PointNotificationEvent e) {
+		// 1) 알림 멱등(있으면 스킵)
+		String keyPart  = (e.dedupKey() != null ? e.dedupKey() : String.valueOf(e.pointHistoryId()));
+		String dedupeKey = "notify:point:" + keyPart;
+
+		StringRedisTemplate redis = redisProvider.getIfAvailable();
+		if (redis != null) {
+			Boolean ok = redis.opsForValue().setIfAbsent(dedupeKey, "1", DEDUPE_TTL);
+			if (!Boolean.TRUE.equals(ok)) {
+				log.debug("[포인트][알림 전송 스킵] 중복 알림 건너뛰기 - key={}", dedupeKey);
+				return;
+			}
+		}
+
+		// 2) DTO 매핑(기존 DTO 재사용)
+		boolean saved = e.amount() >= 0;
+		String title   = saved ? "포인트 적립 안내" : "포인트 사용 안내";
+		String body    = String.format("%s%d점 • 잔액 %d점 • 사유: %s",
+			saved ? "+" : "-", Math.abs(e.amount()), e.balanceAfter(), e.content());
+
+		MemberNotificationRequest req = MemberNotificationRequest.builder()
+			.notificationType("POINT")
+			.memberId(e.memberId())
+			.title(title)
+			.content(body)
+			.code(e.actionType().name())
+			.occurredAt(e.occurredAt())
+			.build();
+
+		// 3) 전송
+		try {
+			notificationClient.sendServiceNotice(req);
+			log.info("[포인트][알림 전송] sent - memberId={}, histId={}, amount={}, balance={}",
+				e.memberId(), e.pointHistoryId(), e.amount(), e.balanceAfter());
+		} catch (Exception ex) {
+			log.error("[포인트][알림 전송 실패] failed - memberId={}, histId={}, err={}",
+				e.memberId(), e.pointHistoryId(), ex.toString(), ex);
+		}
+	}
+}


### PR DESCRIPTION
## 🔍 Title(필수)
#39 
## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result
### 백엔드 로그
<img width="1547" height="286" alt="스크린샷 2025-08-24 213915" src="https://github.com/user-attachments/assets/e3b8750d-dc42-4ffa-a77e-b0438e16002c" />

### 프론트 알림 표시
<img width="383" height="251" alt="스크린샷 2025-08-24 213336" src="https://github.com/user-attachments/assets/e37da005-6149-45e3-97e0-208870eaee48" />
<img width="971" height="400" alt="스크린샷 2025-08-24 213856" src="https://github.com/user-attachments/assets/dfa73b6d-0015-4eb0-8581-08e4b2d8ab1b" />

### 포인트 조회
<img width="1291" height="702" alt="스크린샷 2025-08-24 221651" src="https://github.com/user-attachments/assets/950ecb28-53cc-4422-8cc3-6354b414bcdf" />
잔액 부분을 저번 pr에서 여쭤보신 balanceAfter에서 받아와서 출력 하고 있습니다. (보유 포인트는 member 도메인에서 가져옴)

### 포인트 조회(필터, 기간 내에 없을 시)
<img width="1352" height="773" alt="스크린샷 2025-08-24 221700" src="https://github.com/user-attachments/assets/31f1c3aa-8f6d-4ee6-807e-57b2e58852b8" />

## 🔗 Related Issues(필수)
Closes #39

## 📝 Note (주의 사항)
포인트 적립 및 차감 시 알림 이벤트 발행 기능 추가했습니다.
기존의 멤버 도메인에서 알림 발행하는 dto를 재활용했습니다.
추가로 프론트 화면도 구현해서 pr 해놧습니다. 

