### PR TITLE
✨ feat: 업적 달성 시 알림 이벤트 발행 구현

### DIFF
--- a/src/main/java/com/grow/member_service/achievement/accomplished/infra/persistence/event/AchievementEventHandler.java
+++ b/src/main/java/com/grow/member_service/achievement/accomplished/infra/persistence/event/AchievementEventHandler.java
@@ -4,6 +4,7 @@ import static org.springframework.transaction.event.TransactionPhase.*;
 
 import java.time.LocalDateTime;
 
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -29,6 +30,7 @@ public class AchievementEventHandler {
 	 * 기존 포인트 서비스가 그대로 처리하게 합니다.
 	 * @param e 업적 달성 이벤트 객체
 	 */
+	@Async
 	@TransactionalEventListener(phase = AFTER_COMMIT)
 	public void on(AchievementAchievedEvent e) {
 		log.info("[업적] 이벤트 수신: memberId={}, challengeId={}, reward={}", e.memberId(), e.challengeId(), e.rewardPoint());

--- a/src/main/java/com/grow/member_service/global/config/AsyncConfig.java
+++ b/src/main/java/com/grow/member_service/global/config/AsyncConfig.java
@@ -1,0 +1,8 @@
+package com.grow.member_service.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig { }


### PR DESCRIPTION
## 🔍 Title(필수)
#45 

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result
### 업적 db
<img width="371" height="174" alt="스크린샷 2025-08-27 174539" src="https://github.com/user-attachments/assets/2e5c1d12-06b5-4dc8-af01-bf7fc3a0d1b3" />

### 달성 업적 테이블
<img width="478" height="56" alt="스크린샷 2025-08-27 174708" src="https://github.com/user-attachments/assets/ff8cf6ef-6e52-416d-976c-dc2ba9adea6a" />

### 포인트 히스토리 테이블
<img width="1109" height="51" alt="스크린샷 2025-08-27 174701" src="https://github.com/user-attachments/assets/d5f163d8-eb32-4267-9a69-3e6535ab5b1e" />


### 멤버 서비스 로그
<img width="1380" height="308" alt="스크린샷 2025-08-27 174514" src="https://github.com/user-attachments/assets/276ee431-fc4b-442d-91c5-f3bbe5516792" />
<img width="1532" height="179" alt="스크린샷 2025-08-27 174649" src="https://github.com/user-attachments/assets/003896ab-0a1e-4ee2-b83b-ba92201f3daa" />

### 프론트 알림창
<img width="393" height="201" alt="스크린샷 2025-08-27 174505" src="https://github.com/user-attachments/assets/331d75f0-198b-4f4f-8e70-78c681e0a82f" />
<img width="922" height="311" alt="스크린샷 2025-08-27 174629" src="https://github.com/user-attachments/assets/0b913a04-06ca-40f8-bd3c-73608dadfbbd" />


## 🔗 Related Issues(필수)
Closes #45

## 📝 Note (주의 사항)
### 변경 사항
전역 설정에 Async 추가
업적 리스너 비동기 처리

### 왜 알림 전송이 안 되었는가..?
- 업적을 DB에 저장한 뒤, 애프터 커밋 타이밍에 리스너가 동기적으로 실행되면서 그 자리에서 포인트 적립(트랜잭션)을 호출함
- 이 시점은 트랜잭션 매니저가 커밋 마무리 콜백을 수행 중이라서 새 트랜잭션 바인딩이 불안정
- 결과적으로 포인트 적립 내부 jpa 동작이 실패하거나, id가 확정되지 않는 등 포인트 이벤트 발행이 정상적으로 이루어지지 않아 알림까지 도달하지 못함

### 해결 방법
- 업적 리스너를 비동기(@Async) 로 전환했습니다.
- 애프터 커밋 콜백이 완전히 끝난 뒤 별도 스레드에서 포인트 적립이 실행되므로 트랜잭션이 새 컨텍스트에서 새 트랜잭션을 시작하고 포인트 저장 -> 알림 발행 -> 알림 전송까지 안정적으로 이어집니다.

이제 프론트 만들면서 힐링해야겟네요..
