### PR TITLE
✨ feat: 관리자 권한 관리 API 구현

### DIFF
--- a/src/main/java/com/grow/member_service/admin/application/AdminCommandService.java
+++ b/src/main/java/com/grow/member_service/admin/application/AdminCommandService.java
@@ -1,0 +1,6 @@
+package com.grow.member_service.admin.application;
+
+public interface AdminCommandService {
+	Long grant(Long memberId);
+	void revoke(Long memberId);
+}

--- a/src/main/java/com/grow/member_service/admin/application/AdminQueryService.java
+++ b/src/main/java/com/grow/member_service/admin/application/AdminQueryService.java
@@ -1,0 +1,5 @@
+package com.grow.member_service.admin.application;
+
+public interface AdminQueryService {
+	boolean isAdmin(Long memberId);
+}

--- a/src/main/java/com/grow/member_service/admin/application/impl/AdminCommandServiceImpl.java
+++ b/src/main/java/com/grow/member_service/admin/application/impl/AdminCommandServiceImpl.java
@@ -1,0 +1,55 @@
+package com.grow.member_service.admin.application.impl;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.grow.member_service.admin.application.AdminCommandService;
+import com.grow.member_service.admin.domain.model.AdminAssignment;
+import com.grow.member_service.admin.domain.repository.AdminAssignmentRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminCommandServiceImpl implements AdminCommandService {
+
+	private final AdminAssignmentRepository repository;
+	private final Clock clock;
+
+	/**
+	 * 관리자 권한 부여
+	 * @param memberId 관리자 권한을 부여할 회원 ID
+	 * @return 관리자 권한이 부여된 회원 ID
+	 */
+	@Override
+	@Transactional
+	public Long grant(Long memberId) {
+		// 이미 관리자면 그대로 종료
+		if (repository.existsByMemberId(memberId)) {
+			log.info("[멤버][관리자] 이미 관리자 권한을 가진 회원 - memberId={}", memberId);
+			return memberId;
+		}
+		AdminAssignment saved = repository.save(
+			new AdminAssignment(memberId, LocalDateTime.now(clock))
+		);
+		log.info("[멤버][관리자] 관리자 권한 부여 완료 - memberId={}", memberId);
+		return saved.getMemberId();
+	}
+
+	/**
+	 * 관리자 권한 회수
+	 * @param memberId 관리자 권한을 회수할 회원 ID
+	 */
+	@Override
+	@Transactional
+	public void revoke(Long memberId) {
+		// 존재하지 않아도 예외 없이 성공 처리
+		repository.deleteByMemberId(memberId);
+		log.info("[멤버][관리자] 관리자 권한 해제 완료 - memberId={}", memberId);
+	}
+}

--- a/src/main/java/com/grow/member_service/admin/application/impl/AdminQueryServiceImpl.java
+++ b/src/main/java/com/grow/member_service/admin/application/impl/AdminQueryServiceImpl.java
@@ -1,0 +1,32 @@
+package com.grow.member_service.admin.application.impl;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.grow.member_service.admin.application.AdminQueryService;
+import com.grow.member_service.admin.domain.repository.AdminAssignmentRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminQueryServiceImpl implements AdminQueryService {
+
+	private final AdminAssignmentRepository repository;
+
+	/**
+	 * 관리자 여부 조회
+	 * 추후에 다른 서비스에서 관리자 여부를 조회할 수 있으므로 별도의 서비스로 분리
+	 * @param memberId 회원 ID
+	 * @return 관리자 여부
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public boolean isAdmin(Long memberId) {
+		boolean result = repository.existsByMemberId(memberId);
+		log.debug("[멤버][관리자] 관리자 여부 조회 - memberId={}, result={}", memberId, result);
+		return result;
+	}
+}

--- a/src/main/java/com/grow/member_service/admin/domain/model/AdminAssignment.java
+++ b/src/main/java/com/grow/member_service/admin/domain/model/AdminAssignment.java
@@ -1,0 +1,19 @@
+package com.grow.member_service.admin.domain.model;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import lombok.Getter;
+
+@Getter
+public class AdminAssignment {
+
+	/** memberId 자체가 PK */
+	private final Long memberId;
+	private final LocalDateTime grantedAt;
+
+	public AdminAssignment(Long memberId, LocalDateTime grantedAt) {
+		this.memberId = Objects.requireNonNull(memberId, "멤버 ID가 필요합니다.");
+		this.grantedAt = Objects.requireNonNull(grantedAt, "grantedAt이 필요합니다.");
+	}
+}

--- a/src/main/java/com/grow/member_service/admin/domain/repository/AdminAssignmentRepository.java
+++ b/src/main/java/com/grow/member_service/admin/domain/repository/AdminAssignmentRepository.java
@@ -1,0 +1,9 @@
+package com.grow.member_service.admin.domain.repository;
+
+import com.grow.member_service.admin.domain.model.AdminAssignment;
+
+public interface AdminAssignmentRepository {
+	AdminAssignment save(AdminAssignment assignment);
+	void deleteByMemberId(Long memberId);
+	boolean existsByMemberId(Long memberId);
+}

--- a/src/main/java/com/grow/member_service/admin/infra/persistence/entity/AdminAssignmentJpaEntity.java
+++ b/src/main/java/com/grow/member_service/admin/infra/persistence/entity/AdminAssignmentJpaEntity.java
@@ -1,0 +1,28 @@
+package com.grow.member_service.admin.infra.persistence.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table (name = "admin_assignment")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminAssignmentJpaEntity {
+
+	@Id
+	@Column(name = "member_id")
+	private Long memberId;
+
+	@Column(nullable = false)
+	private LocalDateTime grantedAt;
+}

--- a/src/main/java/com/grow/member_service/admin/infra/persistence/mapper/AdminAssignmentMapper.java
+++ b/src/main/java/com/grow/member_service/admin/infra/persistence/mapper/AdminAssignmentMapper.java
@@ -1,0 +1,15 @@
+package com.grow.member_service.admin.infra.persistence.mapper;
+
+import com.grow.member_service.admin.domain.model.AdminAssignment;
+import com.grow.member_service.admin.infra.persistence.entity.AdminAssignmentJpaEntity;
+
+public class AdminAssignmentMapper {
+
+	public static AdminAssignment toDomain(AdminAssignmentJpaEntity e) {
+		return new AdminAssignment(e.getMemberId(), e.getGrantedAt());
+	}
+
+	public static AdminAssignmentJpaEntity toEntity(AdminAssignment d) {
+		return new AdminAssignmentJpaEntity(d.getMemberId(), d.getGrantedAt());
+	}
+}

--- a/src/main/java/com/grow/member_service/admin/infra/persistence/mapper/AdminAssignmentMapper.java
+++ b/src/main/java/com/grow/member_service/admin/infra/persistence/mapper/AdminAssignmentMapper.java
@@ -6,10 +6,16 @@ import com.grow.member_service.admin.infra.persistence.entity.AdminAssignmentJpa
 public class AdminAssignmentMapper {
 
 	public static AdminAssignment toDomain(AdminAssignmentJpaEntity e) {
+		if (e == null) {
+			return null;
+		}
 		return new AdminAssignment(e.getMemberId(), e.getGrantedAt());
 	}
 
 	public static AdminAssignmentJpaEntity toEntity(AdminAssignment d) {
+		if (d == null) {
+			return null;
+		}
 		return new AdminAssignmentJpaEntity(d.getMemberId(), d.getGrantedAt());
 	}
 }

--- a/src/main/java/com/grow/member_service/admin/infra/persistence/repository/AdminAssignmentJpaRepository.java
+++ b/src/main/java/com/grow/member_service/admin/infra/persistence/repository/AdminAssignmentJpaRepository.java
@@ -1,0 +1,10 @@
+package com.grow.member_service.admin.infra.persistence.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.grow.member_service.admin.infra.persistence.entity.AdminAssignmentJpaEntity;
+
+public interface AdminAssignmentJpaRepository extends JpaRepository<AdminAssignmentJpaEntity, Long> {
+	void deleteByMemberId(Long memberId);
+	boolean existsByMemberId(Long memberId);
+}

--- a/src/main/java/com/grow/member_service/admin/infra/persistence/repository/AdminAssignmentRepositoryImpl.java
+++ b/src/main/java/com/grow/member_service/admin/infra/persistence/repository/AdminAssignmentRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.grow.member_service.admin.infra.persistence.repository;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.grow.member_service.admin.domain.model.AdminAssignment;
+import com.grow.member_service.admin.domain.repository.AdminAssignmentRepository;
+import com.grow.member_service.admin.infra.persistence.mapper.AdminAssignmentMapper;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminAssignmentRepositoryImpl implements AdminAssignmentRepository {
+
+	private final AdminAssignmentJpaRepository jpa;
+
+	@Override
+	@Transactional
+	public AdminAssignment save(AdminAssignment assignment) {
+		return AdminAssignmentMapper.toDomain(jpa.save(AdminAssignmentMapper.toEntity(assignment)));
+	}
+
+	/**
+	 * 관리자 권한 부여 이력 삭제
+	 */
+	@Override
+	@Transactional
+	public void deleteByMemberId(Long memberId) {
+		jpa.deleteByMemberId(memberId);
+	}
+
+	/**
+	 * 관리자 권한 부여 이력이 존재하는지 여부
+	 */
+	@Override
+	@Transactional(readOnly = true)
+	public boolean existsByMemberId(Long memberId) {
+		return jpa.existsByMemberId(memberId);
+	}
+}

--- a/src/main/java/com/grow/member_service/admin/presentation/AdminController.java
+++ b/src/main/java/com/grow/member_service/admin/presentation/AdminController.java
@@ -1,0 +1,48 @@
+package com.grow.member_service.admin.presentation;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.grow.member_service.admin.application.AdminCommandService;
+import com.grow.member_service.admin.application.AdminQueryService;
+import com.grow.member_service.global.dto.RsData;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@Tag(name = "Admin", description = "관리자 권한 관리 API")
+public class AdminController {
+
+	private final AdminCommandService commandService;
+	private final AdminQueryService queryService;
+
+	// 내부용
+	@Operation(summary = "관리자 승급")
+	@PostMapping("/internal/v1/admin/members/{memberId}")
+	public ResponseEntity<RsData<Long>> grant(@PathVariable Long memberId) {
+		Long id = commandService.grant(memberId);
+		return ResponseEntity.ok(new RsData<>("200", "관리자 권한 부여 완료", id));
+	}
+
+	@Operation(summary = "관리자 해제")
+	@DeleteMapping("/internal/v1/admin/members/{memberId}")
+	public ResponseEntity<RsData<Void>> revoke(@PathVariable Long memberId) {
+		commandService.revoke(memberId);
+		return ResponseEntity.ok(new RsData<>("200", "관리자 권한 해제 완료", null));
+	}
+
+	// 외부 서비스용
+	@Operation(summary = "관리자 여부 조회", description = "다른 서비스에서 권한 검증 시 사용")
+	@GetMapping("/api/v1/admin/members/{memberId}/is-admin")
+	public ResponseEntity<RsData<Boolean>> isAdmin(@PathVariable Long memberId) {
+		boolean result = queryService.isAdmin(memberId);
+		return ResponseEntity.ok(new RsData<>("200", "관리자 여부 조회 성공", result));
+	}
+}

--- a/src/main/java/com/grow/member_service/admin/presentation/controller/AdminController.java
+++ b/src/main/java/com/grow/member_service/admin/presentation/controller/AdminController.java
@@ -1,4 +1,4 @@
-package com.grow.member_service.admin.presentation;
+package com.grow.member_service.admin.presentation.controller;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/src/test/java/com/grow/member_service/admin/application/impl/AdminCommandServiceImplTest.java
+++ b/src/test/java/com/grow/member_service/admin/application/impl/AdminCommandServiceImplTest.java
@@ -1,0 +1,92 @@
+package com.grow.member_service.admin.application.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import com.grow.member_service.admin.domain.model.AdminAssignment;
+import com.grow.member_service.admin.domain.repository.AdminAssignmentRepository;
+
+class AdminCommandServiceImplTest {
+
+	private AdminAssignmentRepository repository;
+	private Clock fixedClock;
+	private AdminCommandServiceImpl service;
+
+	@BeforeEach
+	void setUp() {
+		repository = mock(AdminAssignmentRepository.class);
+		fixedClock = Clock.fixed(Instant.parse("2025-09-02T12:00:00Z"), ZoneOffset.UTC);
+		service = new AdminCommandServiceImpl(repository, fixedClock);
+	}
+
+	@Test
+	@DisplayName("이미 관리자면 저장 없이 memberId 반환(멱등)")
+	void grant_whenAlreadyAdmin_thenNoSaveAndReturnMemberId() {
+		// given
+		Long memberId = 100L;
+		when(repository.existsByMemberId(memberId)).thenReturn(true);
+
+		// when
+		Long result = service.grant(memberId);
+
+		// then
+		assertThat(result).isEqualTo(memberId);
+		verify(repository, never()).save(any(AdminAssignment.class));
+		verify(repository).existsByMemberId(memberId);
+		verifyNoMoreInteractions(repository);
+	}
+
+	@Test
+	@DisplayName("관리자 아님 → 저장하고 memberId 반환, grantedAt은 고정 시각")
+	void grant_whenNotAdmin_thenSaveAndReturnMemberId() {
+		// given
+		Long memberId = 200L;
+		when(repository.existsByMemberId(memberId)).thenReturn(false);
+		// save 동작 시 도메인 객체 그대로 반환되도록 설정
+		when(repository.save(any(AdminAssignment.class)))
+			.thenAnswer(invocation -> invocation.getArgument(0, AdminAssignment.class));
+
+		// when
+		Long result = service.grant(memberId);
+
+		// then
+		assertThat(result).isEqualTo(memberId);
+
+		// save 인자로 들어온 도메인 검증 (grantedAt == fixed now)
+		ArgumentCaptor<AdminAssignment> captor = ArgumentCaptor.forClass(AdminAssignment.class);
+		verify(repository).save(captor.capture());
+		AdminAssignment saved = captor.getValue();
+
+		assertThat(saved.getMemberId()).isEqualTo(memberId);
+		assertThat(saved.getGrantedAt())
+			.isEqualTo(LocalDateTime.ofInstant(fixedClock.instant(), fixedClock.getZone()));
+
+		verify(repository).existsByMemberId(memberId);
+		verifyNoMoreInteractions(repository);
+	}
+
+	@Test
+	@DisplayName("revoke는 존재 여부와 관계 없이 deleteByMemberId 호출(멱등)")
+	void revoke_alwaysDeletesOnce() {
+		// given
+		Long memberId = 300L;
+
+		// when
+		service.revoke(memberId);
+
+		// then
+		verify(repository).deleteByMemberId(memberId);
+		verifyNoMoreInteractions(repository);
+	}
+}

--- a/src/test/java/com/grow/member_service/admin/application/impl/AdminQueryServiceImplTest.java
+++ b/src/test/java/com/grow/member_service/admin/application/impl/AdminQueryServiceImplTest.java
@@ -1,0 +1,54 @@
+package com.grow.member_service.admin.application.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.grow.member_service.admin.domain.repository.AdminAssignmentRepository;
+
+class AdminQueryServiceImplTest {
+
+	private AdminAssignmentRepository repository;
+	private AdminQueryServiceImpl service;
+
+	@BeforeEach
+	void setUp() {
+		repository = mock(AdminAssignmentRepository.class);
+		service = new AdminQueryServiceImpl(repository);
+	}
+
+	@Test
+	@DisplayName("isAdmin: 존재하면 true")
+	void isAdmin_true() {
+		// given
+		Long memberId = 10L;
+		when(repository.existsByMemberId(memberId)).thenReturn(true);
+
+		// when
+		boolean result = service.isAdmin(memberId);
+
+		// then
+		assertThat(result).isTrue();
+		verify(repository).existsByMemberId(memberId);
+		verifyNoMoreInteractions(repository);
+	}
+
+	@Test
+	@DisplayName("isAdmin: 없으면 false")
+	void isAdmin_false() {
+		// given
+		Long memberId = 11L;
+		when(repository.existsByMemberId(memberId)).thenReturn(false);
+
+		// when
+		boolean result = service.isAdmin(memberId);
+
+		// then
+		assertThat(result).isFalse();
+		verify(repository).existsByMemberId(memberId);
+		verifyNoMoreInteractions(repository);
+	}
+}

--- a/src/test/java/com/grow/member_service/admin/infra/persistence/mapper/AdminAssignmentMapperTest.java
+++ b/src/test/java/com/grow/member_service/admin/infra/persistence/mapper/AdminAssignmentMapperTest.java
@@ -1,0 +1,55 @@
+package com.grow.member_service.admin.infra.persistence.mapper;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.grow.member_service.admin.domain.model.AdminAssignment;
+import com.grow.member_service.admin.infra.persistence.entity.AdminAssignmentJpaEntity;
+
+class AdminAssignmentMapperTest {
+
+	@Test
+	@DisplayName("toEntity: 도메인 → JPA 엔티티 매핑이 정확해야 한다")
+	void toEntity_success() {
+		// given
+		Long memberId = 10L;
+		LocalDateTime when = LocalDateTime.of(2025, 9, 2, 12, 0, 0);
+		AdminAssignment domain = new AdminAssignment(memberId, when);
+
+		// when
+		AdminAssignmentJpaEntity entity = AdminAssignmentMapper.toEntity(domain);
+
+		// then
+		assertThat(entity).isNotNull();
+		assertThat(entity.getMemberId()).isEqualTo(memberId);
+		assertThat(entity.getGrantedAt()).isEqualTo(when);
+	}
+
+	@Test
+	@DisplayName("toDomain: JPA 엔티티 → 도메인 매핑이 정확해야 한다")
+	void toDomain_success() {
+		// given
+		Long memberId = 20L;
+		LocalDateTime when = LocalDateTime.of(2025, 9, 2, 13, 30, 0);
+		AdminAssignmentJpaEntity entity = new AdminAssignmentJpaEntity(memberId, when);
+
+		// when
+		AdminAssignment domain = AdminAssignmentMapper.toDomain(entity);
+
+		// then
+		assertThat(domain).isNotNull();
+		assertThat(domain.getMemberId()).isEqualTo(memberId);
+		assertThat(domain.getGrantedAt()).isEqualTo(when);
+	}
+
+	@Test
+	@DisplayName("null 매핑: toEntity(null) / toDomain(null) 은 null을 반환해야 한다")
+	void nullMapping_returnsNull() {
+		assertThat(AdminAssignmentMapper.toEntity(null)).isNull();
+		assertThat(AdminAssignmentMapper.toDomain(null)).isNull();
+	}
+}


### PR DESCRIPTION
## 🔍 Title(필수)
#50 

## ✅ Check List(필수)
- [x] 코드에 주석 추가 완료
- [x] 테스트 통과 확인 (`npm test`)
- [x] 문서 업데이트 완료 (`README.md`)

+ 📸 Screenshot or Test Result
### 관리자 권한 부여

<img width="846" height="630" alt="스크린샷 2025-09-02 205352" src="https://github.com/user-attachments/assets/7259bc50-f4a4-4085-8916-e3599cfa6729" />

### 관리자 여부 조회

<img width="836" height="629" alt="스크린샷 2025-09-02 205358" src="https://github.com/user-attachments/assets/d61dae7b-afd1-4d54-b35b-18b60f174ea4" />

### 관리자 권한 삭제
<img width="848" height="622" alt="image" src="https://github.com/user-attachments/assets/50bbd577-f65f-41d6-8e37-910a9a0c6f69" />

### DB
<img width="271" height="136" alt="스크린샷 2025-09-02 205753" src="https://github.com/user-attachments/assets/d69536cc-432a-4212-8d6e-37bd3b9c843f" />

## 🔗 Related Issues(필수)
Closes #50 

## 📝 Note (주의 사항)
멤버와 분리된 애그리거트로 관리자 권한 여부를 단일 플래그로 관리할 수 있도록 추가했습니다.

운영용 내부 api 
- 관리자 권한 부여/삭제 기능

권한 조회 api
- 외부 서비스 통신용으로 구현
- 관리자 여부 확인 