### PR TITLE
✨ feat: MDC 설정 추가 (traceId, requestUri, ip 등 파싱)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,9 @@ dependencies {
 
 	// mysql
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// h2
+	runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grow/member_service/global/filter/MicroserviceMDCFilter.java
+++ b/src/main/java/com/grow/member_service/global/filter/MicroserviceMDCFilter.java
@@ -1,0 +1,70 @@
+package com.grow.member_service.global.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE) // 가장 먼저 실행되도록 설정
+@Component
+public class MicroserviceMDCFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+        HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
+
+        // 게이트웨이로부터 전달된 헤더 읽기
+        String traceId = httpRequest.getHeader("X-Trace-Id");
+        if (traceId == null || traceId.isEmpty()) {
+            traceId = UUID.randomUUID().toString(); // 헤더 없으면 새로 생성
+        }
+
+        String clientIp = httpRequest.getHeader("X-Client-Ip");
+        if (clientIp == null || clientIp.isEmpty()) {
+            clientIp = getClientIp(httpRequest); // 로컬 IP 추출
+        }
+
+        String requestUri = httpRequest.getHeader("X-Request-Uri");
+        if (requestUri == null || requestUri.isEmpty()) {
+            requestUri = httpRequest.getRequestURI(); // 로컬 URI 사용
+        }
+
+        // 응답 헤더에도 추가 (추적을 위해)
+        httpResponse.addHeader("X-Trace-Id", traceId);
+        httpResponse.addHeader("X-Client-Ip", clientIp);
+        httpResponse.addHeader("X-Request-Uri", requestUri);
+
+        // MDC에 값 삽입
+        MDC.put("traceId", traceId);
+        MDC.put("clientIp", clientIp);
+        MDC.put("requestUri", requestUri);
+
+        log.info("[MDC] traceId={}, clientIp={}, requestUri={}", traceId, clientIp, requestUri);
+
+        try {
+            filterChain.doFilter(servletRequest, servletResponse);
+        } finally {
+            // MDC 정리 (메모리 누수 방지)
+            MDC.remove("traceId");
+            MDC.remove("clientIp");
+            MDC.remove("requestUri");
+        }
+    }
+
+    private String getClientIp(HttpServletRequest request) {
+        String xfHeader = request.getHeader("X-Forwarded-For");
+        if (xfHeader != null && !xfHeader.isEmpty()) {
+            return xfHeader.split(",")[0].trim(); // 프록시 고려
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration scan="true">
+
+    <!-- Spring Boot 기본 변수 포함 -->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <springProperty scope="context" name="APP_NAME" source="spring.application.name"/>
+
+    <!-- 로그 디렉토리/파일명 기본값 -->
+    <property name="LOG_HOME" value="${LOG_PATH:-./logs}"/>
+    <property name="MAX_HISTORY" value="30"/>
+    <property name="MAX_FILE_SIZE" value="10MB"/>
+
+    <!-- 콘솔 색상 로그 패턴 -->
+    <property name="LOG_PATTERN"
+              value="%cyan(%d{yyyy-MM-dd HH:mm:ss.SSS}) %highlight(%-5level) [%yellow(%thread)] [%magenta(%X{traceId:-})] %green(%logger{36}) - %msg%n"/>
+
+    <!-- 콘솔 출력 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+            <charset>UTF-8</charset>
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %X{traceId} %X{clientIp} %X{requestUri} %n</pattern>
+            </encoder>
+        </encoder>
+    </appender>
+
+    <!-- 일반 애플리케이션 로그 (롤링) -->
+    <appender name="APP_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_HOME}/${APP_NAME:-app}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_HOME}/archive/${APP_NAME:-app}.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+            <maxFileSize>${MAX_FILE_SIZE}</maxFileSize>
+            <maxHistory>${MAX_HISTORY}</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %X{traceId} %n</pattern>
+            </encoder>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <!-- Hibernate 바인딩 파라미터 로그 전용 파일 -->
+    <appender name="HIBERNATE_BIND_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_HOME}/hibernate-bind.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_HOME}/archive/hibernate-bind.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <!-- Hibernate 바인딩 파라미터 TRACE 로그는 파일로만 저장 (콘솔에는 안 보임) -->
+    <logger name="org.hibernate.orm.jdbc.bind" level="TRACE" additivity="false">
+        <appender-ref ref="HIBERNATE_BIND_FILE"/>
+    </logger>
+
+    <!-- Hibernate SQL 로그는 콘솔/파일 둘 다 출력 -->
+    <logger name="org.hibernate.SQL" level="DEBUG"/>
+
+    <!-- Root Logger -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="APP_FILE"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION

# 아 귀찮아 간단하게 적겠습니다 

```bash
2025-10-08T22:28:21.553+09:00  INFO 42764 --- [ctor-http-nio-7] c.g.g.filter.mdc.WebMDCFilterFactory     : requestUri: /api/v1/members/me
2025-10-08T22:28:21.553+09:00  INFO 42764 --- [ctor-http-nio-7] c.g.g.filter.mdc.WebMDCFilterFactory     : Client IP: /[0:0:0:0:0:0:0:1]:52470
2025-10-08T22:28:21.553+09:00  INFO 42764 --- [ctor-http-nio-7] c.g.g.filter.mdc.WebMDCFilterFactory     : Trace ID: b7bd2ef7-15e7-4701-8921-d4555b33209f
2025-10-08T22:28:21.554+09:00  INFO 42764 --- [ctor-http-nio-7] c.grow.gateway.filter.JwtGatewayFilter   : [Auth Filter] JWT 인증 필터 실행
2025-10-08T22:28:21.561+09:00  INFO 42764 --- [ctor-http-nio-7] c.grow.gateway.filter.JwtGatewayFilter   : [Auth Filter] 인증 성공, memberId: 1
2025-10-08T22:28:21.688+09:00  INFO 42764 --- [ctor-http-nio-7] c.g.g.filter.mdc.WebMDCFilterFactory     : Gateway response completed
```

- 게이트웨이에서 헤더에 담은 요청

```bash
2025-10-08 22:28:21.615 INFO  [http-nio-8081-exec-1] [b7bd2ef7-15e7-4701-8921-d4555b33209f] c.g.m.g.filter.MicroserviceMDCFilter - [MDC] traceId=b7bd2ef7-15e7-4701-8921-d4555b33209f, clientIp=/[0:0:0:0:0:0:0:1]:52470, requestUri=/api/v1/members/me
```

- 멤버에서 요청을 받을 때
- 시간 로그레벨 스레드이름 traceId 클래스명 < 이 순서대로 출력
- 이런 식으로 로그 수집하면 나중에 중앙 처리기에서 확인할 때에도 편할 것 같아요 
- 모든 서버에 그냥 복붙하시면 됩니다 (필터랑 로깅xml) 
- 게이트웨이는 수정해 뒀습니다 
